### PR TITLE
Fix build for newer GCC 6.5b

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -28,7 +28,7 @@ jobs:
     name: build-os3-${{ matrix.variant }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Build (${{ matrix.variant }})
         uses: addnab/docker-run-action@v3
@@ -39,7 +39,7 @@ jobs:
             cd source
             make os3 release ${{ matrix.make_flags }}
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.artifact }}
           path: releases/Dopus5_*_os3*.zip

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/'))
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
 
     steps:
       - name: Download all artifacts
@@ -56,12 +56,10 @@ jobs:
           path: artifacts
           merge-multiple: true
 
-      - name: Create pre-release or release
+      - name: Create release
         uses: ncipollo/release-action@v1
         with:
           artifacts: "artifacts/Dopus5_os3.zip"
-          tag: ${{ github.ref_name }}
-          prerelease: ${{ !startsWith(github.ref, 'refs/tags/') }}
           generateReleaseNotes: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -5,44 +5,42 @@ on:
     branches: [ "master" ]
   pull_request:
     branches: [ "master" ]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
-  build-os3-debug:
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v4
-    
-    - name: Run the build process with Docker
-      uses: addnab/docker-run-action@v3
-      with:
-        image: amigadev/crosstools:m68k-amigaos
-        options: -v ${{ github.workspace }}:/work
-        run: |
-          cd source
-          make os3 release
-          
-    - uses: actions/upload-artifact@v4
-      with:
-        name: Dopus5_92_dev_os3_debug
-        path: releases/Dopus5_92_dev_os3_debug.zip
-
   build-os3:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - variant: debug
+            make_flags: ""
+            artifact: Dopus5_os3_debug
+          - variant: release
+            make_flags: "debug=no"
+            artifact: Dopus5_os3
+
+    name: build-os3-${{ matrix.variant }}
 
     steps:
-    - uses: actions/checkout@v4
-    
-    - name: Run the build process with Docker
-      uses: addnab/docker-run-action@v3
-      with:
-        image: amigadev/crosstools:m68k-amigaos
-        options: -v ${{ github.workspace }}:/work
-        run: |
-          cd source
-          make os3 release debug=no
-          
-    - uses: actions/upload-artifact@v4
-      with:
-        name: Dopus5_92_os3
-        path: releases/Dopus5_92_os3.zip
+      - uses: actions/checkout@v4
+
+      - name: Build (${{ matrix.variant }})
+        uses: addnab/docker-run-action@v3
+        with:
+          image: sacredbanana/amiga-compiler:m68k-amigaos
+          options: -v ${{ github.workspace }}:/work
+          run: |
+            cd source
+            make os3 release ${{ matrix.make_flags }}
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact }}
+          path: releases/Dopus5_*_os3*.zip
+          if-no-files-found: error

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -59,8 +59,8 @@ jobs:
       - name: Create pre-release or release
         uses: ncipollo/release-action@v1
         with:
-          artifacts: "artifacts/*.zip"
-          artifactsIgnore: "artifacts/*_debug.zip"
+          artifacts: "artifacts/Dopus5_os3.zip"
+          tag: ${{ github.ref_name }}
           prerelease: ${{ !startsWith(github.ref, 'refs/tags/') }}
           generateReleaseNotes: true
         env:

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -3,6 +3,8 @@ name: Makefile CI
 on:
   push:
     branches: [ "master" ]
+    tags:
+      - 'v*'
   pull_request:
     branches: [ "master" ]
   workflow_dispatch:
@@ -31,16 +33,35 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Build (${{ matrix.variant }})
-        uses: addnab/docker-run-action@v3
-        with:
-          image: sacredbanana/amiga-compiler:m68k-amigaos
-          options: -v ${{ github.workspace }}:/work
-          run: |
-            cd source
-            make os3 release ${{ matrix.make_flags }}
+        run: |
+          docker run --rm -v ${{ github.workspace }}:/work sacredbanana/amiga-compiler:m68k-amigaos sh -c "cd /work/source && make os3 release ${{ matrix.make_flags }}"
 
       - uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.artifact }}
           path: releases/Dopus5_*_os3*.zip
           if-no-files-found: error
+
+  release:
+    needs: build-os3
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/'))
+
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v8
+        with:
+          path: artifacts
+          merge-multiple: true
+
+      - name: Create pre-release or release
+        uses: ncipollo/release-action@v1
+        with:
+          artifacts: "artifacts/*.zip"
+          artifactsIgnore: "artifacts/*_debug.zip"
+          prerelease: ${{ !startsWith(github.ref, 'refs/tags/') }}
+          generateReleaseNotes: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 */.qtc_clangd/*
 *.o
 */bin.os3/*
+.omg
+.DS_Store
+releases

--- a/catalogs/français/cleanup.ct
+++ b/catalogs/français/cleanup.ct
@@ -1,0 +1,20 @@
+## version $VER: Cleanup.catalog 5.61 (08.07.97) par Georges 'Melkor' Goncalves & Kersten 'Emmy' Emmrich
+## codeset 0
+## language français
+; ************************************************* 
+; Catalog description file for cleanup.module
+; ************************************************* 
+;
+;
+MSG_PLEASE_WAIT
+Veuillez patienter...
+; Please wait...
+;
+MSG_CLEANUP_TITLE
+Directory Opus - Le génie du nettoyage
+; Directory Opus - CleanUp Djinn
+;
+MSG_CLEANUP_DESC
+Procède au nettoyage\x00
+; Perform cleanup maintenance
+;

--- a/catalogs/français/configopus.ct
+++ b/catalogs/français/configopus.ct
@@ -1,0 +1,1856 @@
+## version $VER: ConfigOpus.catalog 5.61 (08.07.97) par Georges 'Melkor' Goncalves & Kersten 'Emmy' Emmrich
+## codeset 0
+## language français
+; ************************************************* 
+; Catalog description file for ConfigOpus
+; Copyright © 1994 Jonathan Potter
+; ************************************************* 
+;
+;
+; Generic strings
+;
+MSG_OKAY
+_Okay
+; _OK
+;
+MSG_CANCEL
+_Annuler\x00
+; _Cancel
+;
+MSG_USE
+_Utiliser
+; _Use
+;
+MSG_PROJECT
+Projet
+; Project
+;
+MSG_SAVE
+_Sauver
+; _Save
+;
+MSG_EDIT
+Editer
+; Edit
+;
+MSG_CUT
+Couper
+; Cut
+;
+MSG_COPY
+Copier
+; Copy
+;
+MSG_PASTE
+Coller
+; Paste
+;
+MSG_ICON_MENU
+Menu icône
+; Icon Menu
+;
+;
+;
+;
+; Settings configuration
+;
+MSG_SETTINGS_TITLE
+
+; Options
+;
+MSG_SETTINGS_SUB_COPY
+Copie
+; Copy
+;
+MSG_SETTINGS_SUB_DELETE
+Effacement
+; Delete
+;
+MSG_SETTINGS_SUB_ICONS
+Icônes
+; Icons
+;
+MSG_SETTINGS_WHEN_COPYING_FILES
+En copiant fichiers et répertoires...
+; When copying files and directories...
+;
+;
+MSG_UNKNOWN_1006
+Ac_tiver le bit Archive
+; 
+;
+MSG_UNKNOWN_1007
+Copier également de la source...\x00
+; 
+;
+MSG_UNKNOWN_1008
+_Date
+; 
+;
+MSG_UNKNOWN_1009
+_Bits de protection
+; 
+;
+MSG_UNKNOWN_1010
+_Commentaire\x00
+; 
+;
+MSG_UNKNOWN_1012
+Demander avant...
+; 
+;
+MSG_UNKNOWN_1013
+Le début de l'_effacement
+; 
+;
+MSG_UNKNOWN_1014
+D'effacer les _fichiers
+; 
+;
+MSG_UNKNOWN_1015
+D'effacer les _répertoires
+; 
+;
+MSG_UNKNOWN_1016
+_Traiter également les icônes
+; 
+;
+MSG_UNKNOWN_1017
+Sé_lection automatique des icônes
+; 
+;
+MSG_UNKNOWN_1018
+Attributs divers...
+; 
+;
+MSG_UNKNOWN_1019
+Gestion des icônes...
+; 
+;
+MSG_UNKNOWN_1026
+Tampons
+; 
+;
+MSG_UNKNOWN_1027
+_Nombre maximum de répertoires
+; 
+;
+MSG_UNKNOWN_1028
+_Désactiver les tampons
+; 
+;
+MSG_UNKNOWN_1029
+_Relire les tampons modifiés\x00
+; 
+;
+MSG_UNKNOWN_1030
+Localisation\x00
+; 
+;
+MSG_UNKNOWN_1031
+Format de la date...\x00
+; 
+;
+MSG_UNKNOWN_1032
+Su_bstituer la date par le nom
+; 
+;
+MSG_UNKNOWN_1033
+Format _12-heures
+; 
+;
+MSG_UNKNOWN_1034
+JJ-MMM-AA    (22-Sep-73)\x00
+; 
+;
+MSG_UNKNOWN_1035
+AA-MM-JJ     (72-06-02)
+; 
+;
+MSG_UNKNOWN_1036
+MM-JJ-AA     (12-03-76)
+; 
+;
+MSG_UNKNOWN_1037
+JJ-MM-AA     (30-10-46)
+; 
+;
+MSG_UNKNOWN_1038
+Iconifier
+; 
+;
+MSG_UNKNOWN_1039
+Méthode d'iconification...
+; 
+;
+MSG_UNKNOWN_1040
+AppIcon (Workbench seulement)
+; 
+;
+MSG_UNKNOWN_1041
+AppMenu (Workbench seulement)
+; 
+;
+MSG_UNKNOWN_1042
+Horloge
+; 
+;
+MSG_UNKNOWN_1043
+Raccourci clavier seulement
+; 
+;
+MSG_UNKNOWN_1044
+_Mettre à jour la destination
+; 
+;
+MSG_UNKNOWN_1046
+Sépa_rer les milliers
+; 
+;
+MSG_UNKNOWN_1048
+Intercepter le programme  « _More »
+; 
+;
+MSG_UNKNOWN_1049
+Divers
+; 
+;
+MSG_UNKNOWN_1050
+Réglages divers...
+; 
+;
+MSG_UNKNOWN_1051
+_Boutons souris sur banques inactives
+; 
+;
+MSG_UNKNOWN_1052
+Priorité\x00
+; 
+;
+MSG_UNKNOWN_1053
+Priorité des tâches...
+; 
+;
+MSG_UNKNOWN_1054
+_Principale
+; 
+;
+MSG_UNKNOWN_1055
+_Listeur\x00
+; 
+;
+MSG_UNKNOWN_1056
+Occupé
+; 
+;
+MSG_UNKNOWN_1057
+Ouvrir options
+; 
+;
+MSG_UNKNOWN_1058
+Sauver options
+; 
+;
+MSG_UNKNOWN_1059
+« %s » n'est pas un fichier options valide !\x00
+; 
+;
+MSG_UNKNOWN_1060
+_Requête de remplacement détaillée 
+; 
+;
+MSG_UNKNOWN_1061
+_Quitter rapidement
+; 
+;
+MSG_UNKNOWN_1062
+Remplacement\x00
+; 
+;
+MSG_UNKNOWN_1063
+En remplaçant les fichiers...
+; 
+;
+MSG_UNKNOWN_1064
+_Vérification automatique de version\x00
+; 
+;
+MSG_UNKNOWN_1065
+S_élection étendue au clavier
+; 
+;
+MSG_UNKNOWN_1066
+_Renifleur de type de fichier
+; 
+;
+MSG_UNKNOWN_1067
+_Raccourci
+; 
+;
+MSG_UNKNOWN_2000
+Environnement
+; 
+;
+MSG_UNKNOWN_2001
+Mode écran
+; 
+;
+MSG_UNKNOWN_2003
+_Mode écran...
+; 
+;
+MSG_UNKNOWN_2004
+_Largeur :
+; 
+;
+MSG_UNKNOWN_2005
+_Hauteur :
+; 
+;
+MSG_UNKNOWN_2006
+Standard\x00
+; 
+;
+MSG_UNKNOWN_2007
+_Couleurs :
+; 
+;
+MSG_UNKNOWN_2008
+Workbench : Utiliser\x00
+; 
+;
+MSG_UNKNOWN_2009
+Workbench : Cloner
+; 
+;
+MSG_UNKNOWN_2010
+_Rouge :\x00
+; 
+;
+MSG_UNKNOWN_2011
+_Vert :
+; 
+;
+MSG_UNKNOWN_2012
+_Bleu :
+; 
+;
+MSG_UNKNOWN_2013
+_Crayons\x00
+; 
+;
+MSG_UNKNOWN_2015
+Exemple
+; 
+;
+MSG_UNKNOWN_2016
+Format listeur
+; 
+;
+MSG_UNKNOWN_2017
+_Eléments listeur
+; 
+;
+MSG_UNKNOWN_2018
+A_vant plan
+; 
+;
+MSG_UNKNOWN_2019
+_Fond
+; 
+;
+MSG_UNKNOWN_2021
+Fichiers\x00
+; 
+;
+MSG_UNKNOWN_2022
+Répertoires
+; 
+;
+MSG_UNKNOWN_2023
+Fich. sélect.
+; 
+;
+MSG_UNKNOWN_2024
+Réps. sélect.
+; 
+;
+MSG_UNKNOWN_2027
+Périphériques
+; 
+;
+MSG_UNKNOWN_2028
+Assignes\x00
+; 
+;
+MSG_UNKNOWN_2029
+Utiliser\x00
+; 
+;
+MSG_UNKNOWN_2033
+_Prefs :\x00
+; 
+;
+MSG_UNKNOWN_2034
+_Défaire\x00
+; 
+;
+MSG_UNKNOWN_2036
+_Réglage...
+; 
+;
+MSG_UNKNOWN_2037
+_Titre :\x00
+; 
+;
+MSG_UNKNOWN_2038
+Taille :\x00
+; 
+;
+MSG_UNKNOWN_2039
+Dimensionnez et positionnez la fenêtre comme désiré.\x00
+; 
+;
+MSG_UNKNOWN_2040
+Cliquez sur la cellule de fermeture pour quitter.
+; 
+;
+MSG_UNKNOWN_2041
+Montrer les « App_Icons »
+; 
+;
+MSG_UNKNOWN_2042
+Montrer le menu « _Outils »
+; 
+;
+MSG_UNKNOWN_2044
+Emulation Workbench...
+; 
+;
+MSG_UNKNOWN_2046
+Choisir une police...
+; 
+;
+MSG_UNKNOWN_2047
+_Cacher les mauvais disques
+; 
+;
+MSG_UNKNOWN_2048
+Options listeur
+; 
+;
+MSG_UNKNOWN_2049
+_Nouveau listeur : Liste périphériques
+; 
+;
+MSG_UNKNOWN_2050
+Taille :\x00
+; 
+;
+MSG_UNKNOWN_2051
+Taille par défaut du listeur\x00
+; 
+;
+MSG_UNKNOWN_2052
+Dimensionnez la fenêtre comme désiré.
+; 
+;
+MSG_UNKNOWN_2053
+_Doubleclic droit : Editer le format\x00
+; 
+;
+MSG_UNKNOWN_2055
+S_tatut :
+; 
+;
+MSG_UNKNOWN_2056
+Choisir le code
+; 
+;
+MSG_UNKNOWN_2057
+_Fenêtre en rafraichissement simple
+; 
+;
+MSG_UNKNOWN_2058
+_Police :
+; 
+;
+MSG_UNKNOWN_2059
+Bureau
+; 
+;
+MSG_UNKNOWN_2060
+Icônes du bureau...
+; 
+;
+MSG_UNKNOWN_2063
+Lecteurs cachés...
+; 
+;
+MSG_UNKNOWN_2064
+_Périph. :
+; 
+;
+MSG_UNKNOWN_2065
+C_harger\x00
+; 
+;
+MSG_UNKNOWN_2066
+Choisir une palette
+; 
+;
+MSG_UNKNOWN_2068
+Options du listeur...
+; 
+;
+MSG_UNKNOWN_2069
+T_itre des champs
+; 
+;
+MSG_UNKNOWN_2070
+T_oujours utiliser la position figée\x00
+; 
+;
+MSG_UNKNOWN_2072
+_Menus contextuels en mode texte\x00
+; 
+;
+MSG_UNKNOWN_2074
+_Edition en ligne
+; 
+;
+MSG_UNKNOWN_2075
+Désactivée
+; 
+;
+MSG_UNKNOWN_2076
+Bouton gauche
+; 
+;
+MSG_UNKNOWN_2077
+Bouton milieu
+; 
+;
+MSG_UNKNOWN_2078
+Gauche & milieu
+; 
+;
+MSG_UNKNOWN_2079
+Utiliser la position _Workbench
+; 
+;
+MSG_UNKNOWN_2080
+_Cache des images d'icônes
+; 
+;
+MSG_UNKNOWN_2081
+_Remapper les images d'icônes
+; 
+;
+MSG_UNKNOWN_2082
+B_ords d'icônes
+; 
+;
+MSG_UNKNOWN_2083
+_Montrer la flèche de Sortie\x00
+; 
+;
+MSG_UNKNOWN_2084
+Réglages d'icône...
+; 
+;
+MSG_UNKNOWN_2085
+Police et couleur des labels...
+; 
+;
+MSG_UNKNOWN_2086
+_Bureau...
+; 
+;
+MSG_UNKNOWN_2087
+_Fenêtres...\x00
+; 
+;
+MSG_UNKNOWN_2088
+Réglages icône
+; 
+;
+MSG_UNKNOWN_2089
+Choisir la police et couleur\x00
+; 
+;
+MSG_UNKNOWN_2090
+Mode :
+; 
+;
+MSG_UNKNOWN_2091
+Texte
+; 
+;
+MSG_UNKNOWN_2092
+Texte + champs
+; 
+;
+MSG_UNKNOWN_2093
+_Déplacer les AppIcons dans « Outils »
+; 
+;
+MSG_UNKNOWN_2094
+_Modifier...\x00
+; 
+;
+MSG_UNKNOWN_2096
+Jauge
+; 
+;
+MSG_UNKNOWN_2097
+Format :\x00
+; 
+;
+MSG_UNKNOWN_2098
+R_égler...
+; 
+;
+MSG_UNKNOWN_2099
+Défaut listeur
+; 
+;
+MSG_UNKNOWN_2100
+_Découper les longs labels
+; 
+;
+MSG_UNKNOWN_2101
+Couleurs listeur\x00
+; 
+;
+MSG_UNKNOWN_2102
+Fenêtre de sortie...\x00
+; 
+;
+MSG_UNKNOWN_2103
+P_ile :
+; 
+;
+MSG_UNKNOWN_2105
+Lancement CLI
+; 
+;
+MSG_UNKNOWN_2106
+Réglages d'affichage listeur...
+; 
+;
+MSG_UNKNOWN_2107
+Fonds
+; 
+;
+MSG_UNKNOWN_2108
+Images de fond...
+; 
+;
+MSG_UNKNOWN_2109
+Utiliser un _motif
+; 
+;
+MSG_UNKNOWN_2110
+_Bureau :
+; 
+;
+MSG_UNKNOWN_2111
+_Fenêtre :
+; 
+;
+MSG_UNKNOWN_2112
+_Requêtes :
+; 
+;
+MSG_UNKNOWN_2113
+Réglages WBPattern...
+; 
+;
+MSG_UNKNOWN_2114
+Utiliser les préférences _WBPattern
+; 
+;
+MSG_UNKNOWN_2115
+Emulation WB\x00
+; 
+;
+MSG_UNKNOWN_2116
+Réglages par défaut du listeur...
+; 
+;
+MSG_UNKNOWN_2117
+_Transparence complète
+; 
+;
+MSG_UNKNOWN_2118
+_Enlever les positions d'icône Opus
+; 
+;
+MSG_UNKNOWN_4000
+Editeur de boutons
+; 
+;
+MSG_UNKNOWN_4001
+_Nom\x00
+; 
+;
+MSG_UNKNOWN_4003
+Colonnes\x00
+; 
+;
+MSG_UNKNOWN_4004
+Lignes
+; 
+;
+MSG_UNKNOWN_4005
+Ajouter
+; 
+;
+MSG_UNKNOWN_4006
+Refaire
+; 
+;
+MSG_UNKNOWN_4007
+Insérer
+; 
+;
+MSG_UNKNOWN_4008
+Effacer
+; 
+;
+MSG_UNKNOWN_4009
+_Police
+; 
+;
+MSG_UNKNOWN_4010
+Choisir la police boutons
+; 
+;
+MSG_UNKNOWN_4011
+Bouton
+; 
+;
+MSG_UNKNOWN_4012
+Copier
+; 
+;
+MSG_UNKNOWN_4013
+Couper
+; 
+;
+MSG_UNKNOWN_4014
+Effacer
+; 
+;
+MSG_UNKNOWN_4015
+Editer
+; 
+;
+MSG_UNKNOWN_4016
+Mode _peinture
+; 
+;
+MSG_UNKNOWN_4017
+_Effacer\x00
+; 
+;
+MSG_UNKNOWN_4018
+Banque
+; 
+;
+MSG_UNKNOWN_4019
+_Cadre complet
+; 
+;
+MSG_UNKNOWN_4020
+Bloc notes
+; 
+;
+MSG_UNKNOWN_4021
+Bouton
+; 
+;
+MSG_UNKNOWN_4022
+Orienter _déplaceur
+; 
+;
+MSG_UNKNOWN_4023
+Automatique
+; 
+;
+MSG_UNKNOWN_4026
+_Boutons sans bords
+; 
+;
+MSG_UNKNOWN_4027
+Rafraîch. s_imple
+; 
+;
+MSG_UNKNOWN_4028
+Apparence
+; 
+;
+MSG_UNKNOWN_4029
+Apparence fenêtre
+; 
+;
+MSG_UNKNOWN_4030
+_Montrer bloc notes
+; 
+;
+MSG_UNKNOWN_4031
+Sans « _oreilles »
+; 
+;
+MSG_UNKNOWN_5000
+Editeur de fonctions\x00
+; 
+;
+MSG_UNKNOWN_5002
+_Raccourci
+; 
+;
+MSG_UNKNOWN_5003
+Attributs
+; 
+;
+MSG_UNKNOWN_5004
+Aj_outer\x00
+; 
+;
+MSG_UNKNOWN_5005
+In_sérer\x00
+; 
+;
+MSG_UNKNOWN_5006
+_Effacer\x00
+; 
+;
+MSG_UNKNOWN_5007
+Commande\x00
+; 
+;
+MSG_UNKNOWN_5014
+Choisir une commande\x00
+; 
+;
+MSG_UNKNOWN_5015
+Choisir un fichier
+; 
+;
+MSG_UNKNOWN_5016
+Choisir un argument
+; 
+;
+MSG_UNKNOWN_5017
+Exporter en ASCII...\x00
+; 
+;
+MSG_UNKNOWN_5018
+Entrer un nom de fichier\x00
+; 
+;
+MSG_UNKNOWN_5020
+Exporter en fichier de commandes...
+; 
+;
+MSG_UNKNOWN_5021
+Lecteurs cachés (mauvais disques seuls)...
+; 
+;
+MSG_UNKNOWN_5022
+_Dossier bureau
+; 
+;
+MSG_UNKNOWN_5023
+_Menu activé\x00
+; 
+;
+MSG_UNKNOWN_5024
+_Par défaut :
+; 
+;
+MSG_UNKNOWN_5025
+Rien\x00
+; 
+;
+MSG_UNKNOWN_5026
+Créer sortie\x00
+; 
+;
+MSG_UNKNOWN_5027
+Déplacer sur le bureau
+; 
+;
+MSG_UNKNOWN_5028
+Copier sur le bureau\x00
+; 
+;
+MSG_UNKNOWN_5029
+Réglages de NewIcons...
+; 
+;
+MSG_UNKNOWN_5030
+A_ctiver NewIcons
+; 
+;
+MSG_UNKNOWN_5031
+_Décourager NewIcons\x00
+; 
+;
+MSG_UNKNOWN_5032
+_Estomper image
+; 
+;
+MSG_UNKNOWN_5033
+_Précision crayon
+; 
+;
+MSG_UNKNOWN_5034
+Affichage icône
+; 
+;
+MSG_UNKNOWN_5035
+Centrer l'image
+; 
+;
+MSG_UNKNOWN_5036
+Sans remappage
+; 
+;
+MSG_UNKNOWN_5037
+Pire résultat
+; 
+;
+MSG_UNKNOWN_5038
+Pauvre résultat
+; 
+;
+MSG_UNKNOWN_5039
+Résultat décent
+; 
+;
+MSG_UNKNOWN_5040
+Meilleur résultat
+; 
+;
+MSG_UNKNOWN_5041
+_Déplacer dans les sous répertoires
+; 
+;
+MSG_UNKNOWN_5042
+_Image
+; 
+;
+MSG_UNKNOWN_20000
+Fenêtre de sortie
+; 
+;
+MSG_UNKNOWN_20001
+Sortie sur fichier
+; 
+;
+MSG_UNKNOWN_20002
+Fenêtre sur le WB
+; 
+;
+MSG_UNKNOWN_20003
+Lancer en asynchrone\x00
+; 
+;
+MSG_UNKNOWN_20006
+Tous les fichiers
+; 
+;
+MSG_UNKNOWN_20007
+Réps récursifs
+; 
+;
+MSG_UNKNOWN_20008
+Relire les fichiers
+; 
+;
+MSG_UNKNOWN_20009
+Pas de guillemets
+; 
+;
+MSG_UNKNOWN_20010
+Relire source
+; 
+;
+MSG_UNKNOWN_20011
+Relire destination
+; 
+;
+MSG_UNKNOWN_20012
+Cellule de fermeture\x00
+; 
+;
+MSG_UNKNOWN_21000
+{f}\tPremière entrée (Chemin)\x00
+; 
+;
+MSG_UNKNOWN_21001
+{fu}\tPremère entrée (Chemin ; Reste sél.)
+; 
+;
+MSG_UNKNOWN_21002
+{F}\tToutes les entrées (Chemin)
+; 
+;
+MSG_UNKNOWN_21003
+{o}\tPremière entrée (Nom seul)
+; 
+;
+MSG_UNKNOWN_21004
+{ou}\tPremière entrée (Nom ; Reste sél.)
+; 
+;
+MSG_UNKNOWN_21005
+{O}\tToutes les entrées (Noms seuls)
+; 
+;
+MSG_UNKNOWN_21006
+{d}\tChemin de destination
+; 
+;
+MSG_UNKNOWN_21007
+{s}\tChemin de source\x00
+; 
+;
+MSG_UNKNOWN_21008
+{f!}\tComme {f} mais optionel\x00
+; 
+;
+MSG_UNKNOWN_21009
+{fu!}\tComme {fu} mais optionel
+; 
+;
+MSG_UNKNOWN_21010
+{F!}\tComme {F} mais optionel\x00
+; 
+;
+MSG_UNKNOWN_21011
+{o!}\tComme {o} mais optionel\x00
+; 
+;
+MSG_UNKNOWN_21012
+{ou!}\tComme {ou} mais optionel
+; 
+;
+MSG_UNKNOWN_21013
+{O!}\tComme {O} mais optionel\x00
+; 
+;
+MSG_UNKNOWN_21014
+{d!}\tComme {d} mais optionel\x00
+; 
+;
+MSG_UNKNOWN_21015
+{s!}\tComme {s} mais optionel\x00
+; 
+;
+MSG_UNKNOWN_21016
+{Qa}\tPasser des arguments à la fonction
+; 
+;
+MSG_UNKNOWN_21017
+{Qd}\tPilote listeur destination
+; 
+;
+MSG_UNKNOWN_21018
+{Ql}\tPilote listeur source
+; 
+;
+MSG_UNKNOWN_21019
+{Qs}\tNom d'écran public
+; 
+;
+MSG_UNKNOWN_21020
+{Qp}\tNom du port ARexx
+; 
+;
+MSG_UNKNOWN_21021
+{Rs}\tRequête de saisie
+; 
+;
+MSG_UNKNOWN_21022
+{RS}\tRequête de saisie sécurisée\x00
+; 
+;
+MSG_UNKNOWN_21023
+{Rf}\tRequête de fichier
+; 
+;
+MSG_UNKNOWN_21024
+{RF}\tRequête de fichier (mode sauvegarde)
+; 
+;
+MSG_UNKNOWN_21025
+{Rd}\tRequête de répertoire
+; 
+;
+MSG_UNKNOWN_21026
+{v}\tVariable d'environnement\x00
+; 
+;
+MSG_UNKNOWN_22000
+*bs\tTaille fichiers & répertoires sél.
+; 
+;
+MSG_UNKNOWN_22001
+*bt\tTaille totale fichiers & répertoires\x00
+; 
+;
+MSG_UNKNOWN_22002
+*ds\tNombre de répertoires sélectionnés
+; 
+;
+MSG_UNKNOWN_22003
+*dt\tNombre de répertoires
+; 
+;
+MSG_UNKNOWN_22004
+*fs\tNombre de fichiers sélectionnés
+; 
+;
+MSG_UNKNOWN_22005
+*ft\tNombre de fichiers
+; 
+;
+MSG_UNKNOWN_22006
+*h*\tNombre de fichiers cachés
+; 
+;
+MSG_UNKNOWN_6000
+Editeur de boutons
+; 
+;
+MSG_UNKNOWN_6001
+Fonctions
+; 
+;
+MSG_UNKNOWN_6002
+_Nom\x00
+; 
+;
+MSG_UNKNOWN_6005
+E_diter fonction...
+; 
+;
+MSG_UNKNOWN_6006
+Bouton gauche
+; 
+;
+MSG_UNKNOWN_6007
+Bouton droit\x00
+; 
+;
+MSG_UNKNOWN_6008
+Bouton milieu
+; 
+;
+MSG_UNKNOWN_6010
+Choisir les couleurs\x00
+; 
+;
+MSG_UNKNOWN_6011
+A_vant plan
+; 
+;
+MSG_UNKNOWN_6012
+_Fond
+; 
+;
+MSG_UNKNOWN_6013
+Bouton
+; 
+;
+MSG_UNKNOWN_6014
+Aj_outer\x00
+; 
+;
+MSG_UNKNOWN_6015
+_Effacer\x00
+; 
+;
+MSG_UNKNOWN_6016
+Nouvelle fonction
+; 
+;
+MSG_UNKNOWN_7000
+Conversion de la configuration
+; 
+;
+MSG_UNKNOWN_7001
+Ancienne configuration detectée.\x00
+; 
+;
+MSG_UNKNOWN_7002
+Quelles sections convertir ?\x00
+; 
+;
+MSG_UNKNOWN_7004
+_Boutons\x00
+; 
+;
+MSG_UNKNOWN_7006
+_Lecteurs
+; 
+;
+MSG_UNKNOWN_7007
+_Types de fichiers
+; 
+;
+MSG_UNKNOWN_7008
+_Raccourcis
+; 
+;
+MSG_UNKNOWN_7009
+_Nom de base\x00
+; 
+;
+MSG_UNKNOWN_7010
+_Convertir
+; 
+;
+MSG_UNKNOWN_7011
+ancien
+; 
+;
+MSG_UNKNOWN_7012
+Conversion de l'ancienne configuration...
+; 
+;
+MSG_UNKNOWN_7013
+_Environnement
+; 
+;
+MSG_UNKNOWN_8000
+Types de fichiers
+; 
+;
+MSG_UNKNOWN_8001
+Aj_outer\x00
+; 
+;
+MSG_UNKNOWN_8002
+_Dupliquer
+; 
+;
+MSG_UNKNOWN_8003
+S_upprimer
+; 
+;
+MSG_UNKNOWN_8004
+_Sauver
+; 
+;
+MSG_UNKNOWN_8005
+Stoc_ker\x00
+; 
+;
+MSG_UNKNOWN_8006
+_Définition...
+; 
+;
+MSG_UNKNOWN_8007
+Double clic
+; 
+;
+MSG_UNKNOWN_8008
+TirerDéposer\x00
+; 
+;
+MSG_UNKNOWN_8009
+Utilisateur1\x00
+; 
+;
+MSG_UNKNOWN_8010
+Utilisateur2\x00
+; 
+;
+MSG_UNKNOWN_8011
+Utilisateur3\x00
+; 
+;
+MSG_UNKNOWN_8012
+Utilisateur4\x00
+; 
+;
+MSG_UNKNOWN_8019
+Editeur type de fichier
+; 
+;
+MSG_UNKNOWN_8020
+Vraiment supprimer le type\n« %s » ?
+; 
+;
+MSG_UNKNOWN_8021
+_Choisir icône...
+; 
+;
+MSG_UNKNOWN_8022
+Icône du type de fichier\x00
+; 
+;
+MSG_UNKNOWN_8023
+_Editer
+; 
+;
+MSG_UNKNOWN_8024
+E_vènements...
+; 
+;
+MSG_UNKNOWN_8025
+Menu _icône...
+; 
+;
+MSG_UNKNOWN_8026
+_Editer
+; 
+;
+MSG_UNKNOWN_8027
+Ed_iter
+; 
+;
+MSG_UNKNOWN_8028
+Aj_outer\x00
+; 
+;
+MSG_UNKNOWN_8029
+Efface_r\x00
+; 
+;
+MSG_UNKNOWN_8030
+Icône...\x00
+; 
+;
+MSG_UNKNOWN_8031
+E_ffacer\x00
+; 
+;
+MSG_UNKNOWN_8032
+Utilisateur5\x00
+; 
+;
+MSG_UNKNOWN_8033
+Utilisateur6\x00
+; 
+;
+MSG_UNKNOWN_8034
+Utilisateur7\x00
+; 
+;
+MSG_UNKNOWN_8035
+Utilisateur8\x00
+; 
+;
+MSG_UNKNOWN_8036
+Utilisateur9\x00
+; 
+;
+MSG_UNKNOWN_8037
+Utilisateur10
+; 
+;
+MSG_UNKNOWN_8038
+Double clic (Shift)
+; 
+;
+MSG_UNKNOWN_8039
+TirerDéposer (Shift)\x00
+; 
+;
+MSG_UNKNOWN_8040
+Double clic (CTRL)
+; 
+;
+MSG_UNKNOWN_8041
+TirerDéposer (CTRL)
+; 
+;
+MSG_UNKNOWN_8042
+Double clic (Alt)
+; 
+;
+MSG_UNKNOWN_8043
+TirerDéposer (Alt)
+; 
+;
+MSG_UNKNOWN_9005
+_Nom\x00
+; 
+;
+MSG_UNKNOWN_9007
+Aj_outer\x00
+; 
+;
+MSG_UNKNOWN_9008
+_Enlever\x00
+; 
+;
+MSG_UNKNOWN_9010
+Match name
+; 
+;
+MSG_UNKNOWN_9012
+Match bits
+; 
+;
+MSG_UNKNOWN_9013
+Match comment
+; 
+;
+MSG_UNKNOWN_9014
+Comparer date
+; 
+;
+MSG_UNKNOWN_9015
+Match size
+; 
+;
+MSG_UNKNOWN_9016
+Search for
+; 
+;
+MSG_UNKNOWN_9017
+Find chunk
+; 
+;
+MSG_UNKNOWN_9019
+Move to
+; 
+;
+MSG_UNKNOWN_9022
+_Insérer\x00
+; 
+;
+MSG_UNKNOWN_9027
+Correspond aux octets
+; 
+;
+MSG_UNKNOWN_9028
+Nom de fichier
+; 
+;
+MSG_UNKNOWN_9029
+Le type IFF FORM\x00
+; 
+;
+MSG_UNKNOWN_9030
+Bits de protection
+; 
+;
+MSG_UNKNOWN_9031
+Commentaire du fichier
+; 
+;
+MSG_UNKNOWN_9032
+Date de création\x00
+; 
+;
+MSG_UNKNOWN_9033
+Taille du fichier
+; 
+;
+MSG_UNKNOWN_9034
+Recherche des octets\x00
+; 
+;
+MSG_UNKNOWN_9035
+Cherche un chunk IFF\x00
+; 
+;
+MSG_UNKNOWN_9036
+Saut à position relative\x00
+; 
+;
+MSG_UNKNOWN_9037
+Saut à position absolue
+; 
+;
+MSG_UNKNOWN_9038
+Doit être aussi « vrai »\x00
+; 
+;
+MSG_UNKNOWN_9039
+Si cela échoue, essayer ceci\x00
+; 
+;
+MSG_UNKNOWN_9040
+Un groupe datatypes
+; 
+;
+MSG_UNKNOWN_9041
+Un ID datatype
+; 
+;
+MSG_UNKNOWN_9042
+En ignorant les min/MAJ
+; 
+;
+MSG_UNKNOWN_9044
+Le type « répertoire »
+; 
+;
+MSG_UNKNOWN_9045
+_Visionner...
+; 
+;
+MSG_UNKNOWN_9046
+Choisir le fichier à visionner
+; 
+;
+MSG_UNKNOWN_9047
+Sound module\x00
+; 
+;
+MSG_UNKNOWN_9048
+Inovamusic.library requise
+; 
+;
+MSG_UNKNOWN_9050
+Le type « disque »
+; 
+;
+MSG_UNKNOWN_10001
+_Utiliser
+; 
+;
+MSG_UNKNOWN_10002
+_Annuler\x00
+; 
+;
+MSG_UNKNOWN_10010
+Nouveau
+; 
+;
+MSG_UNKNOWN_10011
+Ouvrir...
+; 
+;
+MSG_UNKNOWN_10012
+Sauver
+; 
+;
+MSG_UNKNOWN_10013
+Sauver en...\x00
+; 
+;
+MSG_UNKNOWN_10014
+Quitter
+; 
+;
+MSG_UNKNOWN_10018
+Sauver|Perdre
+; 
+;
+MSG_UNKNOWN_10019
+Sauver|Perdre|Annuler
+; 
+;
+MSG_UNKNOWN_10020
+SansTitre
+; 
+;
+MSG_UNKNOWN_10021
+_Sauver
+; 
+;
+MSG_UNKNOWN_10022
+Perdre|Annuler
+; 
+;
+MSG_UNKNOWN_10023
+Valeurs par défaut
+; 
+;
+MSG_UNKNOWN_10024
+Dernières valeurs sauvées
+; 
+;
+MSG_UNKNOWN_10025
+Valeurs initiales
+; 
+;
+MSG_UNKNOWN_11001
+_Eléments...\x00
+; 
+;
+MSG_UNKNOWN_11002
+Aj_outer\x00
+; 
+;
+MSG_UNKNOWN_11003
+_Insérer\x00
+; 
+;
+MSG_UNKNOWN_11004
+E_ffacer\x00
+; 
+;
+MSG_UNKNOWN_11007
+Edi_ter
+; 
+;
+MSG_UNKNOWN_11008
+_Nom\x00
+; 
+;
+MSG_UNKNOWN_11009
+Sauver le menu
+; 
+;
+MSG_UNKNOWN_11010
+Ouvrir le menu
+; 
+;
+MSG_UNKNOWN_11011
+Le menu courant (%s) a été modifié.\nVoulez-vous le sauver avant de continuer ?
+; 
+;
+MSG_UNKNOWN_11012
+Le menu courant (%s) a été modifié.\nVoulez-vous le perdre ?
+; 
+;
+MSG_UNKNOWN_11013
+Du_pliquer
+; 
+;
+MSG_UNKNOWN_11014
+Sauver raccourcis
+; 
+;
+MSG_UNKNOWN_11015
+Ouvrir raccourcis
+; 
+;
+MSG_UNKNOWN_11016
+Le fichier de raccourcis (%s) a été modifié.\nVoulez-vous le sauver avant de continuer ?
+; 
+;
+MSG_UNKNOWN_11017
+Le fichier de raccourcis (%s) a été modifié.\nVoulez-vous le détruire ?
+; 
+;
+MSG_UNKNOWN_11018
+_Raccourci global au système\x00
+; 
+;
+MSG_UNKNOWN_11019
+Sauver scripts
+; 
+;
+MSG_UNKNOWN_11020
+Ouvrir scripts
+; 
+;
+MSG_UNKNOWN_11021
+Le fichier script (%s) a été modifié.\nVoulez-vous le sauver avant de continuer ?\x00
+; 
+;
+MSG_UNKNOWN_11022
+Le fichier script (%s) a été modifié.\nVoulez-vous le détruire ?
+; 
+;
+MSG_UNKNOWN_12001
+Erreur en sauvant !
+; 
+;
+MSG_UNKNOWN_12002
+Erreur DOS
+; 
+;
+MSG_UNKNOWN_12003
+Réessayer|Annuler
+; 
+;
+MSG_UNKNOWN_12004
+Erreur en sauvant !\nErreur DOS %ld%s\x00
+; 
+;
+MSG_UNKNOWN_12005
+Erreur en chargeant !\nErreur DOS %ld%s
+; 
+;
+MSG_UNKNOWN_13000
+      Nom : \x00
+; 
+;
+MSG_UNKNOWN_13001
+    Image : \x00
+; 
+;
+MSG_UNKNOWN_13002
+    Label : \x00
+; 
+;
+MSG_UNKNOWN_13003
+Raccourci : \x00
+; 
+;
+MSG_UNKNOWN_13004
+ Fonction : \x00
+; 
+;
+MSG_UNKNOWN_13005
+Attributs : \x00
+; 
+;
+MSG_UNKNOWN_14000
+Démarrage
+; 
+;
+MSG_UNKNOWN_14001
+Extinction
+; 
+;
+MSG_UNKNOWN_14002
+Iconification
+; 
+;
+MSG_UNKNOWN_14003
+Réapparition\x00
+; 
+;
+MSG_UNKNOWN_14004
+Disque inséré
+; 
+;
+MSG_UNKNOWN_14005
+Disque illisible inséré
+; 
+;
+MSG_UNKNOWN_14006
+Disque enlevé
+; 
+;
+MSG_UNKNOWN_14007
+Double clic
+; 
+;
+MSG_UNKNOWN_14008
+Ouverture de listeur\x00
+; 
+;
+MSG_UNKNOWN_14009
+Ouverture de boutons\x00
+; 
+;
+MSG_UNKNOWN_14010
+Ouverture de groupe
+; 
+;
+MSG_UNKNOWN_14011
+Fermeture de listeur\x00
+; 
+;
+MSG_UNKNOWN_14012
+Fermeture de boutons\x00
+; 
+;
+MSG_UNKNOWN_14013
+Fermeture de groupe
+; 
+;
+MSG_UNKNOWN_14014
+Double clic droit
+; 
+;
+MSG_UNKNOWN_14015
+Double clic milieu
+; 
+;
+MSG_UNKNOWN_15000
+Menus utilisateur
+; 
+;
+MSG_UNKNOWN_15002
+_Elément menu
+; 
+;
+MSG_UNKNOWN_15003
+_Sous menu
+; 
+;
+MSG_UNKNOWN_15004
+Ajout
+; 
+;
+MSG_UNKNOWN_15005
+Copier
+; 
+;
+MSG_UNKNOWN_15006
+Eff.\x00
+; 
+;
+MSG_UNKNOWN_15007
+Edit.
+; 
+;
+MSG_UNKNOWN_15008
+Menu utilisateur\x00
+; 
+;
+MSG_UNKNOWN_15009
+Nouveau menu\x00
+; 
+;
+MSG_UNKNOWN_15010
+Nouvel élément
+; 
+;
+MSG_UNKNOWN_15011
+Menu listeur\x00
+; 
+;
+MSG_UNKNOWN_15012
+Menu listeur\x00
+; 
+;
+MSG_UNKNOWN_15013
+Remplacer|Annuler
+; 
+;
+MSG_UNKNOWN_15014
+Le fichier « %s » existe déjà\nOkay pour le remplacer ?
+; 
+;
+MSG_UNKNOWN_15015
+Okay\x00
+; 
+;
+MSG_UNKNOWN_15016
+« %s »\nn'est pas un fichier boutons valide !\x00
+; 
+;
+MSG_UNKNOWN_15017
+Haut\x00
+; 
+;
+MSG_UNKNOWN_15018
+Bas
+; 
+;
+MSG_UNKNOWN_15019
+Raccourcis menu
+; 
+;
+MSG_UNKNOWN_15020
+Raccourcis menu
+; 
+;
+MSG_UNKNOWN_15021
+_RAmiga +
+; 
+;
+MSG_UNKNOWN_15022
+Menu démarrer
+; 
+;
+MSG_UNKNOWN_15023
+Menu démarrer
+; 

--- a/catalogs/français/diskcopy.ct
+++ b/catalogs/français/diskcopy.ct
@@ -1,0 +1,161 @@
+## version $VER: DiskCopy.catalog 5.61 (08.07.1997)
+## codeset 0
+## language français
+; ************************************************* 
+; Catalog description file for diskcopy.module
+; ************************************************* 
+;
+;
+MSG_DISKCOPY_TITLE
+Copie de disque
+; Diskcopy
+;
+MSG_DISKCOPY_DISKCOPY
+_Copier
+; _Diskcopy
+;
+MSG_DISKCOPY_CANCEL
+_Annuler\x00
+; _Cancel
+;
+MSG_DISKCOPY_VERIFY
+_Vérifier
+; _Verify
+;
+MSG_DISKCOPY_BUMP
+« C_opie de »
+; _Bump Name
+;
+MSG_DISKCOPY_FROM
+Depuis...
+; From...
+;
+MSG_DISKCOPY_TO
+Vers...
+; To...
+;
+MSG_DISKCOPY_STATUS
+%s, %s utilisés
+; %s, %s used
+;
+MSG_DISKCOPY_OPEN_DEVICES
+Ouvertures des périphériques...
+; Opening devices...
+;
+MSG_CANT_OPEN_DEVICE
+Impossible d'ouvrir la source !
+; Can't open source device!
+;
+MSG_NO_DISK_PRESENT
+Pas de disque présent dans la destination !
+; No disk present in source!
+;
+MSG_CANT_OPEN_DESTINATION
+Impossible d'ouvrir la destination %s
+; Unable to open destination %s
+;
+MSG_NO_DISK_PRESENT_DEST
+Pas de disque présent dans %s
+; No disk present in %s
+;
+MSG_WRITE_PROTECTED_DEST
+Le disque dans %s est protegé en écriture !
+; Disk in %s is write protected!
+;
+MSG_ABORTED
+Annulé.
+; Aborted.
+;
+MSG_RETRY_CANCEL
+Réessayer|Annuler
+; Retry|Cancel
+;
+MSG_RETRY_REMOVE_CANCEL
+Réessayer|Enlever|Annuler
+; Retry|Remove|Cancel
+;
+MSG_PROCEED_CANCEL
+Continuer|Annuler
+; Proceed|Cancel
+;
+MSG_DISKCOPY_SUCCESSFUL
+Copie de disque réussie !
+; Diskcopy successful!
+;
+MSG_DISKCOPY_FAILED
+Copie de disque échouée.\x00
+; Diskcopy failed.
+;
+MSG_READ_ERROR
+Erreur en lisant %s à la piste %ld\n%s
+; Error reading %s track %ld\n%s
+;
+MSG_WRITE_ERROR
+Erreur en écrivant %s à la piste %ld\n%s
+; Error writing %s track %ld\n%s
+;
+MSG_VERIFY_ERROR
+Erreur en vérifiant %s à la piste %ld\n%s\x00
+; Error verifying %s track %ld\n%s
+;
+MSG_DISKCOPY_READING
+Lecture de la piste %ld, reste %ld.
+; Reading track %ld, %ld to go.
+;
+MSG_DISKCOPY_WRITING
+Ecriture de la piste %ld, reste %ld.\x00
+; Writing track %ld, %ld to go.
+;
+MSG_DISKCOPY_VERIFYING
+Vérification de la piste %ld, reste %ld.\x00
+; Verifying track %ld, %ld to go.
+;
+MSG_DISKCOPY_TO_TITLE
+vers\x00
+; to
+;
+MSG_INSERT_DESTINATION
+Inserez le disque destination en %s
+; Insert destination disk in %s
+;
+MSG_INSERT_SOURCE
+Inserez le disque source en %s
+; Insert source disk in %s
+;
+MSG_ERROR_WRITE_PROT
+Disque protégé en écriture
+; Disk is write protected
+;
+MSG_ERROR_NO_DISK
+Pas de disque dans le lecteur
+; No disk in drive
+;
+MSG_ERROR_UNKNOWN
+Code d'erreur inconnu
+; Unknown error code
+;
+MSG_ERROR_VERIFY
+Données non inscrites correctement.
+; Data not written correctly.
+;
+MSG_BUMPING_NAMES
+Décalage des noms...\x00
+; Bumping names...
+;
+MSG_INCOMPATIBLE
+Les disques sont incompatibles et donc incopiables.
+; Disks are of incompatible types and can not be copied.
+;
+MSG_OK
+Okay\x00
+; OK
+;
+;
+MSG_DISKCOPY_DESC
+Crée des copies d'un disque
+; Make copies of a disk
+;
+MSG_DISKCOPY_COPYING
+Copie du disque...
+; Copying disk...
+;

--- a/catalogs/français/diskinfo.ct
+++ b/catalogs/français/diskinfo.ct
@@ -1,0 +1,252 @@
+## version $VER: DiskInfo.catalog 5.61 (08.07.1997)
+## codeset 0
+## language français
+; ************************************************* 
+; Catalog description file for diskinfo.module
+; ************************************************* 
+;
+; This catalog is for the replacement diskinfo.module with
+; the 3D pie graph. You must set the catalog version to 56
+; for it to work.
+;
+;
+MSG_DISKINFO_TITLE
+Informations sur le disque
+; %b (%s) Information
+;
+MSG_DISKINFO_DESC
+Informations sur périphérique
+; Show information about a device
+;
+MSG_OK
+Disque :\x00
+; _OK
+;
+MSG_CANCEL
+Nom :
+; _Cancel
+;
+MSG_NAME
+Taille :\x00
+; _Name:
+;
+MSG_HANDLER
+Util. :
+; Handler:
+;
+MSG_TYPE
+Libres :\x00
+; Type:
+;
+MSG_STATE
+Pourcent :
+; State:
+;
+MSG_USED
+Densité :
+; Used:
+;
+MSG_FREE
+Erreurs :
+; Free:
+;
+MSG_CAPACITY
+Statut :\x00
+; Total:
+;
+MSG_UNIT
+Date :
+; unit
+;
+MSG_UNKNOWN
+Système :
+; unknown
+;
+MSG_READ_WRITE
+octets 
+; Read/Write
+;
+MSG_READ_ONLY
+blocs 
+; Read Only
+;
+MSG_VALIDATING
+pleins 
+; Validating
+;
+MSG_BYTES
+libres
+;  bytes
+;
+MSG_ERROR
+octets/bloc
+; %ld error
+;
+MSG_ERRORS
+
+; %ld errors
+;
+;
+;
+; DOS types
+;
+MSG_DOSTYPE_1
+
+; Old File System
+;
+MSG_DOSTYPE_2
+
+; Fast File System
+;
+MSG_DOSTYPE_3
+
+; Old File System (International)
+;
+MSG_DOSTYPE_4
+
+; Fast File System (International)
+;
+MSG_DOSTYPE_5
+
+; Old File System (Dir-Caching)
+;
+MSG_DOSTYPE_6
+
+; Fast File System (Dir-Caching)
+;
+MSG_DOSTYPE_7
+
+; MS-DOS (CrossDOS)
+;
+MSG_DOSTYPE_8
+
+; Ami-FileSafe Pro
+;
+MSG_DOSTYPE_9
+
+; Ami-FileSafe User
+;
+MSG_DOSTYPE_10
+
+; Ami-FileSafe Multi
+;
+MSG_DOSTYPE_11
+
+; PFS Floppy
+;
+MSG_DOSTYPE_12
+
+; PFS Hard Drive
+;
+MSG_DOSTYPE_13
+
+; Envoy Network Volume
+;
+MSG_DOSTYPE_14
+
+; Personal File System 2
+;
+MSG_DOSTYPE_15
+
+; Personal File System 3
+;
+MSG_DOSTYPE_16
+
+; Personal File System 2 SCSI
+;
+MSG_DOSTYPE_17
+
+; Personal File System 3 SCSI
+;
+MSG_DOSTYPE_18
+
+; Personal File System Multiuser
+;
+MSG_DOSTYPE_19
+
+; Fast File System (FFS-LNFS)
+;
+MSG_DOSTYPE_20
+
+; Vector Based File System
+;
+MSG_DOSTYPE_21
+
+; Smart File System 0
+;
+MSG_DOSTYPE_22
+
+; Smart File System 1
+;
+MSG_DOSTYPE_23
+
+; Smart File System 2
+;
+MSG_DOSTYPE_24
+
+; Smart File System 3
+;
+MSG_DOSTYPE_25
+
+; JX File System
+;
+MSG_DOSTYPE_26
+
+; Box File System
+;
+MSG_DOSTYPE_27
+
+; FAT32 File System
+;
+MSG_DOSTYPE_28
+
+; exFat File System
+;
+MSG_DOSTYPE_29
+
+; FUSE ext2 File System
+;
+MSG_DOSTYPE_30
+
+; FUSE HFS
+;
+MSG_DOSTYPE_31
+
+; NTFS
+;
+MSG_DOSTYPE_32
+
+; Swap
+;
+;
+MSG_UNKNOWN_1019
+Disque illisible\x00
+; 
+;
+MSG_UNKNOWN_1020
+Disque non DOS
+; 
+;
+MSG_UNKNOWN_1021
+Disque Kickstart\x00
+; 
+;
+MSG_UNKNOWN_1022
+En validation
+; 
+;
+MSG_UNKNOWN_1023
+Protégé en écriture
+; 
+;
+MSG_UNKNOWN_1024
+Lecture/Ecriture\x00
+; 
+;
+MSG_UNKNOWN_1025
+Erreur DOS
+; 
+;
+MSG_UNKNOWN_1026
+_Continuer
+; 

--- a/catalogs/français/dopus.ct
+++ b/catalogs/français/dopus.ct
@@ -1,0 +1,1970 @@
+## version $VER: DOpus.catalog 5.61 (08.07.1997)
+## codeset 0
+## language français
+; ************************************************* 
+; Catalog description file for Directory Opus
+; Copyright © 1994-98 Jonathan Potter, GPSoftware
+; DO NOT REDISTRIBUTE!
+; ************************************************* 
+;
+;
+; Generic strings
+;
+MSG_ABORTED
+Annulé...
+; Aborted...
+;
+MSG_TRY_AGAIN
+Réessayer
+; Try Again
+;
+MSG_RETRY
+Réessayer
+; Retry
+;
+MSG_ABORT
+Annuler
+; Abort
+;
+MSG_REPLACE
+Remplacer
+; Replace
+;
+MSG_SKIP
+Passer
+; Skip
+;
+MSG_SKIP_ALL
+Passer tout
+; Skip All
+;
+MSG_ALL
+Tout\x00
+; All
+;
+MSG_QUIT
+Quitter
+; Quit
+;
+MSG_SAVE
+Sauver
+; Save
+;
+MSG_CLOSE
+Fermer
+; Close
+;
+MSG_YES
+Oui
+; Yes
+;
+MSG_NO
+Non
+; No
+;
+MSG_CONTINUE
+Continuer
+; Continue
+;
+MSG_OKAY
+Okay\x00
+; OK
+;
+MSG_CANCEL
+Annuler
+; Cancel
+;
+MSG_REPLACE_ALL
+Remplacer tout
+; Replace All
+;
+MSG_PROCEED
+Continuer
+; Proceed
+;
+MSG_MOVE
+Déplacer\x00
+; Move
+;
+MSG_DISCARD
+Détruire\x00
+; Discard
+;
+MSG_BLOCKS
+blocs
+; blocks
+;
+MSG_FREE
+libres
+; free
+;
+MSG_MAKELINK
+Créer lien
+; MakeLink
+;
+MSG_SELECT_FILE
+Choisir un fichier
+; Select File
+;
+MSG_SELECT_DIR
+Choisir un répertoire
+; Select Directory
+;
+MSG_ENTER_FILE
+Entrez un nom de fichier\x00
+; Enter Filename
+;
+MSG_OPEN
+Ouvrir...
+; Open...
+;
+MSG_DEFAULTS
+Valeurs par défaut
+; Reset To Defaults
+;
+MSG_LAST_SAVED
+Dernières valeurs sauvées
+; Last Saved
+;
+MSG_RESTORE
+Valeurs initiales
+; Restore
+;
+MSG_PROJECT
+Projet
+; Project
+;
+MSG_EDIT
+Editer
+; Edit
+;
+MSG_UNKNOWN_TYPE
+<inconnu>
+; <unknown>
+;
+MSG_SNIFF_CONFIRMATION
+Le fichier « %s » ne peut être identifié.\nLancer le renifleur de type de fichier ?
+; The file '%s' could not be identified.\nLaunch Filetype Sniffer to investigate?
+;
+MSG_SNIFF
+Renifler !
+; Sniff!
+;
+MSG_SCRIPTS_CHANGED
+Vous avez modifié les scripts sans\nles sauver. Voulez vous les sauver ?
+; You have modified your scripts and not\nsaved them. Would you like to?
+;
+MSG_LISTER_MENU_CHANGED
+Vous avez modifé le menu des listeurs\nsans les sauver. Voulez vous les sauver ?
+; You have modified your lister menu and not\nsaved it. Would you like to?
+;
+MSG_USER_MENU_CHANGED
+Vous avez modifié les menus utilisateur\nsans les sauver. Voulez vous les sauver ?
+; You have modified your user menus and not\nsaved them. Would you like to?
+;
+MSG_HOTKEYS_CHANGED
+Vous avez modifié les raccourcis sans\nles sauver. Voulez vous les sauver ?
+; You have modified your hotkeys and not\nsaved them. Would you like to?
+;
+MSG_OPEN_NEW_WINDOW
+Ouvrir en nouveau listeur
+; Open in New Lister
+;
+MSG_OPEN_WITH_MENU
+Ouvrir avec...
+; Open With...
+;
+MSG_SELECT_APP
+Choisir application pour « %s »
+; Select Application To Open '%s'
+;
+MSG_OPEN_WITH_MENU_SUB
+Ouvrir avec
+; Open With
+;
+MSG_OPEN_WITH_MENU_OTHER
+Autre...\x00
+; Other...
+;
+;
+;
+;
+; Other strings
+;
+MSG_ENTER_ARGUMENTS_FOR
+Entrez les arguments pour « %s »\x00
+; Enter arguments for '%s'
+;
+MSG_DIRECTORY
+Répertoire
+; Directory 
+;
+MSG_SELECT_UNPROTECT
+\nChoisir « Déprotéger » pour activer\nle bit d'effacement.
+; \nSelect Unprotect to set the deletion bit.
+;
+MSG_FOUND_A_MATCH
+Chaîne trouvée dans le fichier\n« %s »
+; Found a match in the file\n'%s'
+;
+MSG_COMMENTING
+commentant
+; commenting
+;
+MSG_PROTECTING
+protégeant
+; protecting
+;
+MSG_DATESTAMPING
+datant
+; date stamping
+;
+MSG_DELETING
+effaçant\x00
+; deleting
+;
+MSG_RENAMING
+renommant
+; renaming
+;
+MSG_ENTER_COMMENT
+Entrez un commentaire pour\n« %s »
+; Enter a comment for '%s'.
+;
+MSG_ENTER_PASSWORD
+Entrez le mot de passe pour le cryptage
+; Enter password to encrypt files.
+;
+MSG_ENTER_DATE_AND_TIME
+Entrez la nouvelle date (et heure) pour « %s »
+; Enter new date (and time) for '%s'.
+;
+MSG_ENTER_ARGUMENTS
+Entrez les arguments\x00
+; Enter arguments
+;
+MSG_REALLY_QUIT
+Cela terminera votre session\nDirectory Opus.\x00
+; This will end your Directory Opus session.
+;
+MSG_FILE
+Fichier
+; File
+;
+MSG_SELECT_PROTECTION_BITS
+Choisir les bits de protection
+; Select protection bits
+;
+MSG_DIRECTORY_OPUS_REQUEST
+Requête Directory Opus
+; Directory Opus Request
+;
+;
+MSG_UNKNOWN_1020
+Tirage multiple - %ld fichiers, %ld réps choisis\x00
+; 
+;
+MSG_UNKNOWN_1021
+Cliquez le bouton de fermeture pour continuer...\x00
+; 
+;
+MSG_UNKNOWN_1022
+commenter
+; 
+;
+MSG_UNKNOWN_1023
+protéger\x00
+; 
+;
+MSG_UNKNOWN_1024
+dater
+; 
+;
+MSG_UNKNOWN_1025
+Déplacement en cours...
+; 
+;
+MSG_UNKNOWN_1026
+Chargement du programme... Veuillez patienter
+; 
+;
+MSG_UNKNOWN_1027
+Charger...
+; 
+;
+MSG_UNKNOWN_1028
+Sauver
+; 
+;
+MSG_UNKNOWN_1029
+Sauver en...\x00
+; 
+;
+MSG_UNKNOWN_1030
+Agir récursivement dans\nles sous répertoires ?
+; 
+;
+MSG_UNKNOWN_1031
+Mise des commentaires...\x00
+; 
+;
+MSG_UNKNOWN_1032
+Mise des bits de protection...
+; 
+;
+MSG_UNKNOWN_1033
+Mise des dates...
+; 
+;
+MSG_UNKNOWN_1034
+Courant
+; 
+;
+MSG_UNKNOWN_1035
+Activer
+; 
+;
+MSG_UNKNOWN_1036
+Effacer
+; 
+;
+MSG_UNKNOWN_1037
+_Okay
+; 
+;
+MSG_UNKNOWN_1038
+_Tous
+; 
+;
+MSG_UNKNOWN_1039
+_Passer
+; 
+;
+MSG_UNKNOWN_1040
+_Annuler\x00
+; 
+;
+MSG_UNKNOWN_1041
+Cryptage en cours...\x00
+; 
+;
+MSG_UNKNOWN_1042
+Utilisateur
+; 
+;
+MSG_UNKNOWN_1043
+Menu furtif listeur
+; 
+;
+MSG_UNKNOWN_1044
+Menu utilisateur\x00
+; 
+;
+MSG_UNKNOWN_1045
+vide\x00
+; 
+;
+MSG_UNKNOWN_1046
+_Annuler\x00
+; 
+;
+MSG_UNKNOWN_1047
+_Ouvrir
+; 
+;
+MSG_UNKNOWN_1048
+_Nouveau\x00
+; 
+;
+MSG_UNKNOWN_1049
+Répertoire parent
+; 
+;
+MSG_UNKNOWN_1050
+Répertoire racine
+; 
+;
+MSG_UNKNOWN_1051
+Liste des périphériques
+; 
+;
+MSG_UNKNOWN_1052
+Examen des répertoires...
+; 
+;
+MSG_UNKNOWN_1053
+Lecture du répertoire...\x00
+; 
+;
+MSG_UNKNOWN_1054
+Résultat du test de place disponible :\n
+; 
+;
+MSG_UNKNOWN_1055
+Tient à
+; 
+;
+MSG_UNKNOWN_1056
+blocs requis.
+; 
+;
+MSG_UNKNOWN_1057
+Entrez la commande et arguments.\x00
+; 
+;
+MSG_UNKNOWN_1058
+Outils
+; 
+;
+MSG_UNKNOWN_1059
+Liste des tampons
+; 
+;
+MSG_UNKNOWN_1060
+Relire répertoire
+; 
+;
+MSG_UNKNOWN_1061
+Assigner\x00
+; 
+;
+MSG_UNKNOWN_1062
+pleins
+; 
+;
+MSG_UNKNOWN_1063
+utilisés\x00
+; 
+;
+MSG_UNKNOWN_1064
+en validation
+; 
+;
+MSG_UNKNOWN_1065
+Répertoires sélectionnés - Entrez le motif filtre.
+; 
+;
+MSG_UNKNOWN_1067
+Choisir source
+; 
+;
+MSG_UNKNOWN_1068
+Choisir destination
+; 
+;
+MSG_UNKNOWN_1069
+<Pas de propriétaire>
+; 
+;
+MSG_UNKNOWN_1070
+<Pas de groupe>
+; 
+;
+MSG_UNKNOWN_1072
+Création des liens...
+; 
+;
+MSG_UNKNOWN_1073
+en créant un lien sur
+; 
+;
+MSG_UNKNOWN_1074
+_Décrypter fichiers
+; 
+;
+MSG_UNKNOWN_1075
+Vider la corbeille
+; 
+;
+MSG_UNKNOWN_1076
+Le contenu de la corbeille sera perdu !\nVoulez vous vraiment la vider ?
+; 
+;
+MSG_UNKNOWN_1077
+Entrez un nom à assigner à « %s »
+; 
+;
+MSG_UNKNOWN_1078
+Ajouter
+; 
+;
+MSG_UNKNOWN_1079
+Chemin
+; 
+;
+MSG_UNKNOWN_1080
+Différé
+; 
+;
+MSG_UNKNOWN_1081
+assignant
+; 
+;
+MSG_UNKNOWN_1082
+Certains changements effectués ne prendront\neffet qu'au prochain démarrage.
+; 
+;
+MSG_UNKNOWN_1083
+ouvrant
+; 
+;
+MSG_UNKNOWN_1084
+Impossible d'ouvrir %s (%s)
+; 
+;
+MSG_UNKNOWN_1085
+n'importe quelle version\x00
+; 
+;
+MSG_UNKNOWN_1087
+Le remplaçant Workbench complet !
+; 
+;
+MSG_UNKNOWN_1088
+Voulez vous annuler le démarrage ?
+; 
+;
+MSG_UNKNOWN_1089
+Continuer|Annuler
+; 
+;
+MSG_UNKNOWN_1090
+Proteger\x00
+; 
+;
+MSG_UNKNOWN_1091
+Dater
+; 
+;
+MSG_UNKNOWN_1092
+Commenter
+; 
+;
+MSG_UNKNOWN_1093
+L'image de fond est désactivée dans l'environnement.\nVoulez vous l'activer ?\x00
+; 
+;
+MSG_UNKNOWN_2000
+Cette copie est enregistrée à :
+; 
+;
+MSG_UNKNOWN_2001
+N° de série : 
+; 
+;
+MSG_UNKNOWN_2002
+Cette copie n'est pas enregistrée !
+; 
+;
+MSG_UNKNOWN_2003
+Enregistrez vous pour éviter ce délai !
+; 
+;
+MSG_UNKNOWN_2004
+Traduction française par\nGeorges 'Melkor' Goncalves\n& Kersten 'Emmy' Emmrich. \n
+; 
+;
+MSG_UNKNOWN_2100
+Chercher les fichiers dans les\nrépertoires sélectionnés ?
+; 
+;
+MSG_UNKNOWN_2101
+Entrez le texte à chercher...
+; 
+;
+MSG_UNKNOWN_2102
+_Ignorer min/MAJ\x00
+; 
+;
+MSG_UNKNOWN_2103
+_Motifs
+; 
+;
+MSG_UNKNOWN_2104
+M_ots complets
+; 
+;
+MSG_UNKNOWN_2105
+Garder sélectionné
+; 
+;
+MSG_UNKNOWN_2106
+Demander\x00
+; 
+;
+MSG_UNKNOWN_2107
+Résultat en sortie
+; 
+;
+MSG_UNKNOWN_2108
+Recherche en cours...
+; 
+;
+MSG_UNKNOWN_2109
+Fichiers contenant « %s »\n\n
+; 
+;
+MSG_UNKNOWN_2110
+Lire\x00
+; 
+;
+MSG_UNKNOWN_2200
+Entrez le nouveau nom ou un motif
+; 
+;
+MSG_UNKNOWN_2201
+Renomination...
+; 
+;
+MSG_UNKNOWN_2202
+Renommer\x00
+; 
+;
+MSG_UNKNOWN_2203
+Entrez un nouveau nom pour « %s »
+; 
+;
+MSG_UNKNOWN_2204
+Entrez un autre nom de fichier
+; 
+;
+MSG_UNKNOWN_2300
+Entrez le nom du répertoire
+; 
+;
+MSG_UNKNOWN_2301
+Avec icône
+; 
+;
+MSG_UNKNOWN_2302
+Sans icône
+; 
+;
+MSG_UNKNOWN_2303
+Répertoire créé.\x00
+; 
+;
+MSG_UNKNOWN_2400
+Ajout des icônes en cours...\x00
+; 
+;
+MSG_UNKNOWN_2401
+Une icône existe déjà pour « %s »\nVoulez vous le remplacer ?\x00
+; 
+;
+MSG_UNKNOWN_2402
+Image seule
+; 
+;
+MSG_UNKNOWN_2600
+copiant
+; 
+;
+MSG_UNKNOWN_2601
+Copie en cours...
+; 
+;
+MSG_UNKNOWN_2602
+Les répertoires source et destination\ndoivent être différents pour copier\nles fichiers.
+; 
+;
+MSG_UNKNOWN_2603
+Copier
+; 
+;
+MSG_UNKNOWN_2604
+Duplication en cours...
+; 
+;
+MSG_UNKNOWN_2605
+Dupliquer
+; 
+;
+MSG_UNKNOWN_2606
+Vous ne pouvez pas copier un\nrépertoire sur lui même !
+; 
+;
+MSG_UNKNOWN_2607
+déplaçant
+; 
+;
+MSG_UNKNOWN_2608
+Les répertoires source et destination\ndoivent être différents pour créer des liens.
+; 
+;
+MSG_UNKNOWN_2609
+Vous ne pouvez pas lier un\nrépertoire à lui même !
+; 
+;
+MSG_UNKNOWN_2610
+De « %s » à « %s »
+; 
+;
+MSG_UNKNOWN_2611
+De « %s »
+; 
+;
+MSG_UNKNOWN_2701
+Mise en arrière plan\x00
+; 
+;
+MSG_UNKNOWN_2702
+A propos...
+; 
+;
+MSG_UNKNOWN_2703
+Cacher
+; 
+;
+MSG_UNKNOWN_2704
+Quitter...
+; 
+;
+MSG_UNKNOWN_2705
+Executer une commande...\x00
+; 
+;
+MSG_UNKNOWN_2706
+Aide !
+; 
+;
+MSG_UNKNOWN_2707
+Recherche de touche...
+; 
+;
+MSG_UNKNOWN_2800
+Listeurs\x00
+; 
+;
+MSG_UNKNOWN_2801
+Nouveau
+; 
+;
+MSG_UNKNOWN_2802
+Fermer
+; 
+;
+MSG_UNKNOWN_2803
+Passer en source\x00
+; 
+;
+MSG_UNKNOWN_2804
+Passer en destination
+; 
+;
+MSG_UNKNOWN_2805
+Bloquer en source
+; 
+;
+MSG_UNKNOWN_2806
+Bloquer en destination
+; 
+;
+MSG_UNKNOWN_2807
+Débloquer
+; 
+;
+MSG_UNKNOWN_2808
+Eteindre\x00
+; 
+;
+MSG_UNKNOWN_2809
+Débloquer tout
+; 
+;
+MSG_UNKNOWN_2810
+Fermer tout
+; 
+;
+MSG_UNKNOWN_2811
+Editer...
+; 
+;
+MSG_UNKNOWN_2812
+Editer la barre d'outils...
+; 
+;
+MSG_UNKNOWN_2813
+Editer le menu...
+; 
+;
+MSG_UNKNOWN_2814
+Disposer\x00
+; 
+;
+MSG_UNKNOWN_2815
+Horizontalement
+; 
+;
+MSG_UNKNOWN_2816
+Verticalement
+; 
+;
+MSG_UNKNOWN_2817
+Cascader\x00
+; 
+;
+MSG_UNKNOWN_2818
+Bloquer position ?
+; 
+;
+MSG_UNKNOWN_2819
+Iconifier
+; 
+;
+MSG_UNKNOWN_2820
+Voir icônes
+; 
+;
+MSG_UNKNOWN_2821
+Afficher par\x00
+; 
+;
+MSG_UNKNOWN_2822
+Noms\x00
+; 
+;
+MSG_UNKNOWN_2823
+Icône
+; 
+;
+MSG_UNKNOWN_2824
+Montrer tout\x00
+; 
+;
+MSG_UNKNOWN_2825
+Icône action\x00
+; 
+;
+MSG_UNKNOWN_2826
+Réorganiser icônes
+; 
+;
+MSG_UNKNOWN_2827
+Par nom
+; 
+;
+MSG_UNKNOWN_2828
+Par type\x00
+; 
+;
+MSG_UNKNOWN_2829
+Par taille
+; 
+;
+MSG_UNKNOWN_2830
+Par date\x00
+; 
+;
+MSG_UNKNOWN_2831
+Nouveau répertoire...
+; 
+;
+MSG_UNKNOWN_2832
+Ouvrir parent
+; 
+;
+MSG_UNKNOWN_2900
+Icônes
+; 
+;
+MSG_UNKNOWN_2901
+Ouvrir
+; 
+;
+MSG_UNKNOWN_2902
+Informations...
+; 
+;
+MSG_UNKNOWN_2903
+Figer
+; 
+;
+MSG_UNKNOWN_2904
+Sortir
+; 
+;
+MSG_UNKNOWN_2905
+Ranger
+; 
+;
+MSG_UNKNOWN_2906
+Sélectionner tout
+; 
+;
+MSG_UNKNOWN_2907
+Réorganiser
+; 
+;
+MSG_UNKNOWN_2908
+Réinitialiser
+; 
+;
+MSG_UNKNOWN_2909
+Renommer...
+; 
+;
+MSG_UNKNOWN_2910
+Formater...
+; 
+;
+MSG_UNKNOWN_2911
+Informations...
+; 
+;
+MSG_UNKNOWN_2912
+Libérer
+; 
+;
+MSG_UNKNOWN_2913
+Fenêtre
+; 
+;
+MSG_UNKNOWN_2914
+Copier
+; 
+;
+MSG_UNKNOWN_2915
+Nouveau
+; 
+;
+MSG_UNKNOWN_2916
+Répertoire...
+; 
+;
+MSG_UNKNOWN_2917
+Groupe...
+; 
+;
+MSG_UNKNOWN_2918
+Vers RAM:
+; 
+;
+MSG_UNKNOWN_2919
+Vers DF0:
+; 
+;
+MSG_UNKNOWN_2920
+Vers autre...
+; 
+;
+MSG_UNKNOWN_2921
+Copier...
+; 
+;
+MSG_UNKNOWN_2922
+vers\x00
+; 
+;
+MSG_UNKNOWN_2923
+Commande...
+; 
+;
+MSG_UNKNOWN_2924
+Créer raccourci
+; 
+;
+MSG_UNKNOWN_2925
+Créer une sortie\x00
+; 
+;
+MSG_UNKNOWN_2926
+Copier sur le bureau\x00
+; 
+;
+MSG_UNKNOWN_2927
+Déplacer sur le bureau
+; 
+;
+MSG_UNKNOWN_2928
+sur le bureau
+; 
+;
+MSG_UNKNOWN_3000
+Boutons
+; 
+;
+MSG_UNKNOWN_3001
+Nouveau...
+; 
+;
+MSG_UNKNOWN_3002
+Fermer
+; 
+;
+MSG_UNKNOWN_3003
+Boutons graphiques...
+; 
+;
+MSG_UNKNOWN_3004
+Boutons textuels...
+; 
+;
+MSG_UNKNOWN_3005
+Menu démarrer...\x00
+; 
+;
+MSG_UNKNOWN_3100
+Réglages\x00
+; 
+;
+MSG_UNKNOWN_3101
+Horloge
+; 
+;
+MSG_UNKNOWN_3102
+Créer icônes ?
+; 
+;
+MSG_UNKNOWN_3103
+Environnement
+; 
+;
+MSG_UNKNOWN_3104
+Types de fichiers...\x00
+; 
+;
+MSG_UNKNOWN_3105
+Raccourcis...
+; 
+;
+MSG_UNKNOWN_3106
+Menu utilisateur...
+; 
+;
+MSG_UNKNOWN_3107
+Filtre récursif
+; 
+;
+MSG_UNKNOWN_3109
+Sauver disposition ?\x00
+; 
+;
+MSG_UNKNOWN_3110
+Ecran public par défaut
+; 
+;
+MSG_UNKNOWN_3112
+Raccourcis clavier...
+; 
+;
+MSG_UNKNOWN_3113
+Raccourcis clavier
+; 
+;
+MSG_UNKNOWN_3115
+Menus système...\x00
+; 
+;
+MSG_UNKNOWN_3116
+Positionnement d'icônes...
+; 
+;
+MSG_UNKNOWN_3200
+Sélection de fichier\x00
+; 
+;
+MSG_UNKNOWN_3201
+Ignorer
+; 
+;
+MSG_UNKNOWN_3202
+Identique
+; 
+;
+MSG_UNKNOWN_3203
+Différent
+; 
+;
+MSG_UNKNOWN_3204
+Plus récent
+; 
+;
+MSG_UNKNOWN_3205
+Ancien
+; 
+;
+MSG_UNKNOWN_3206
+Différent
+; 
+;
+MSG_UNKNOWN_3207
+_Nom\x00
+; 
+;
+MSG_UNKNOWN_3209
+à
+; 
+;
+MSG_UNKNOWN_3210
+Bits oui\x00
+; 
+;
+MSG_UNKNOWN_3211
+Inclure
+; 
+;
+MSG_UNKNOWN_3212
+Exclure
+; 
+;
+MSG_UNKNOWN_3213
+_Comparer destination
+; 
+;
+MSG_UNKNOWN_3215
+Complexe\x00
+; 
+;
+MSG_UNKNOWN_3216
+Entrez le motif de sélection des fichiers
+; 
+;
+MSG_UNKNOWN_3217
+non
+; 
+;
+MSG_UNKNOWN_3218
+Fich. & Rép.\x00
+; 
+;
+MSG_UNKNOWN_3219
+Fich. seuls
+; 
+;
+MSG_UNKNOWN_3220
+Réps seuls
+; 
+;
+MSG_UNKNOWN_3221
+Ag_ir sur
+; 
+;
+MSG_UNKNOWN_3300
+Erreur DOS
+; 
+;
+MSG_UNKNOWN_3301
+Erreur %ld
+; 
+;
+MSG_UNKNOWN_3302
+Une erreur s'est produite en\n%s « %s »\n%s
+; 
+;
+MSG_UNKNOWN_3303
+La destination\n« %s »\nest un répertoire.\x00
+; 
+;
+MSG_UNKNOWN_3304
+La destination\n« %s »\nest un fichier.
+; 
+;
+MSG_UNKNOWN_3306
+Code d'erreur inconnu
+; 
+;
+MSG_UNKNOWN_3307
+Erreur en sauvant la banque de boutons !\x00
+; 
+;
+MSG_UNKNOWN_3308
+Erreur en chargeant la banque de boutons !
+; 
+;
+MSG_UNKNOWN_3309
+créant le répertoire\x00
+; 
+;
+MSG_UNKNOWN_3310
+Le port de gestion spécial\n« %s »\nne peut être trouvé !
+; 
+;
+MSG_UNKNOWN_3311
+Directory Opus semble être déjà lancé.\nSouhaitez vous lancer une autre copie ?
+; 
+;
+MSG_UNKNOWN_3312
+Lancer|Annuler
+; 
+;
+MSG_UNKNOWN_3313
+Directory Opus est incapable de fermer son écran.\nVeuillez fermer toutes les fenêtres et réessayer.
+; 
+;
+MSG_UNKNOWN_3314
+La date entrée est invalide !
+; 
+;
+MSG_UNKNOWN_3315
+Impossible d'ouvrir l'écran !
+; 
+;
+MSG_UNKNOWN_3316
+Une erreur s'est produite
+; 
+;
+MSG_UNKNOWN_3317
+Erreur
+; 
+;
+MSG_UNKNOWN_3318
+Taille
+; 
+;
+MSG_UNKNOWN_3320
+Ancien
+; 
+;
+MSG_UNKNOWN_3321
+Nouveau
+; 
+;
+MSG_UNKNOWN_3322
+Le fichier « %s »\nexiste déjà !
+; 
+;
+MSG_UNKNOWN_3400
+Effacement en cours...
+; 
+;
+MSG_UNKNOWN_3401
+Attention : Il est impossible de\nrécupérer ce que vous effacez !\nOkay pour effacer :\n\n%ld fichier(s) et\n%ld répertoire(s) (et leur contenu) ?
+; 
+;
+MSG_UNKNOWN_3402
+Effacer
+; 
+;
+MSG_UNKNOWN_3403
+Effacer tout\x00
+; 
+;
+MSG_UNKNOWN_3404
+Effacer « %s » ?\x00
+; 
+;
+MSG_UNKNOWN_3405
+« %s » est un répertoire.\nPoursuivre l'effacement ?
+; 
+;
+MSG_UNKNOWN_3406
+« %s » est protégé contre l'effacement.\nDéprotéger et réessayer ?
+; 
+;
+MSG_UNKNOWN_3407
+Déprotéger
+; 
+;
+MSG_UNKNOWN_3408
+Déprotéger tout
+; 
+;
+MSG_UNKNOWN_3409
+Vraiment effacer ce raccourci ?
+; 
+;
+MSG_UNKNOWN_3410
+Vraiment effacer ces raccourcis ?
+; 
+;
+MSG_UNKNOWN_3500
+Sauver boutons
+; 
+;
+MSG_UNKNOWN_3501
+Charger boutons
+; 
+;
+MSG_UNKNOWN_3502
+Statut des boutons
+; 
+;
+MSG_UNKNOWN_3503
+Chargement de la banque de boutons...
+; 
+;
+MSG_UNKNOWN_3504
+Sauver environnement\x00
+; 
+;
+MSG_UNKNOWN_3505
+Charger environnement
+; 
+;
+MSG_UNKNOWN_3506
+Chargement du fichier environnement...
+; 
+;
+MSG_UNKNOWN_3507
+Sauvegarde du fichier environnement...
+; 
+;
+MSG_UNKNOWN_3508
+La banque de boutons « %s »\na été modifié. Souhaitez vous la sauver ?
+; 
+;
+MSG_UNKNOWN_3509
+Quel type de banque de boutons\nsouhaitez vous créer ?
+; 
+;
+MSG_UNKNOWN_3510
+Texte
+; 
+;
+MSG_UNKNOWN_3511
+Graphique
+; 
+;
+MSG_UNKNOWN_3512
+Charger options
+; 
+;
+MSG_UNKNOWN_3513
+Chargement du fichier options...\x00
+; 
+;
+MSG_UNKNOWN_3514
+Sauver options
+; 
+;
+MSG_UNKNOWN_3515
+Sauvegarde du fichier options...\x00
+; 
+;
+MSG_UNKNOWN_3516
+Erreur en sauvant le fichier environnement !\x00
+; 
+;
+MSG_UNKNOWN_3517
+Erreur en sauvant le fichier options !
+; 
+;
+MSG_UNKNOWN_3602
+Tentative de lancement de « %s »...
+; 
+;
+MSG_UNKNOWN_3603
+%s - %ld mémoire graphique  %ld autre mémoire
+; 
+;
+MSG_UNKNOWN_3604
+%s - %lU mémoire graphique  %lU autre mémoire
+; 
+;
+MSG_UNKNOWN_3605
+%s - %ld graphique  %ld autre
+; 
+;
+MSG_UNKNOWN_3606
+%s - %lU graphique  %lU autre
+; 
+;
+MSG_UNKNOWN_3702
+FONC\x00
+; 
+;
+MSG_UNKNOWN_3703
+RIEN\x00
+; 
+;
+MSG_UNKNOWN_3800
+Entrez le motif du fichier à chercher
+; 
+;
+MSG_UNKNOWN_3801
+Le fichier « %s »\na été trouvé dans le répertoire\n« %s »\nDoit on y aller ?
+; 
+;
+MSG_UNKNOWN_3802
+Nouveau listeur
+; 
+;
+MSG_UNKNOWN_3900
+Ajoute les icônes
+; 
+;
+MSG_UNKNOWN_3901
+Sélectionne tout\x00
+; 
+;
+MSG_UNKNOWN_3902
+Libère les tampons
+; 
+;
+MSG_UNKNOWN_3903
+Ajoute les commentaires
+; 
+;
+MSG_UNKNOWN_3904
+Copie les fichiers
+; 
+;
+MSG_UNKNOWN_3905
+Copie sous d'autres noms\x00
+; 
+;
+MSG_UNKNOWN_3906
+Change la date des fichiers
+; 
+;
+MSG_UNKNOWN_3907
+Efface les fichiers
+; 
+;
+MSG_UNKNOWN_3908
+Copie les disques
+; 
+;
+MSG_UNKNOWN_3909
+Crypte les fichiers
+; 
+;
+MSG_UNKNOWN_3910
+Cherche les fichiers\x00
+; 
+;
+MSG_UNKNOWN_3911
+Finit commandes précédentes
+; 
+;
+MSG_UNKNOWN_3912
+Formate les disques
+; 
+;
+MSG_UNKNOWN_3913
+Calcule la taille des réps
+; 
+;
+MSG_UNKNOWN_3914
+Montre/édite les infos icône\x00
+; 
+;
+MSG_UNKNOWN_3915
+Sort les objets
+; 
+;
+MSG_UNKNOWN_3916
+Lit fichier boutons
+; 
+;
+MSG_UNKNOWN_3917
+Crée un répertoire
+; 
+;
+MSG_UNKNOWN_3918
+Déplace les fichiers\x00
+; 
+;
+MSG_UNKNOWN_3919
+Déplace sous d'autres noms
+; 
+;
+MSG_UNKNOWN_3920
+Désélectionne tout
+; 
+;
+MSG_UNKNOWN_3921
+Joue les sons
+; 
+;
+MSG_UNKNOWN_3922
+Imprime les fichiers\x00
+; 
+;
+MSG_UNKNOWN_3923
+Change bits de protection
+; 
+;
+MSG_UNKNOWN_3924
+Lit les fichiers texte
+; 
+;
+MSG_UNKNOWN_3925
+Renomme les fichiers\x00
+; 
+;
+MSG_UNKNOWN_3926
+Lance les programmes\x00
+; 
+;
+MSG_UNKNOWN_3927
+Lit un répertoire
+; 
+;
+MSG_UNKNOWN_3928
+Cherche du texte\x00
+; 
+;
+MSG_UNKNOWN_3929
+Sélectionne par motifs
+; 
+;
+MSG_UNKNOWN_3930
+Affiche les images
+; 
+;
+MSG_UNKNOWN_3931
+Visionne texte/hexa auto\x00
+; 
+;
+MSG_UNKNOWN_3932
+Inverse la sélection\x00
+; 
+;
+MSG_UNKNOWN_3933
+Vérifie la place disponible
+; 
+;
+MSG_UNKNOWN_3934
+Efface la taille des réps
+; 
+;
+MSG_UNKNOWN_3935
+Visionneur de texte (ANSI)
+; 
+;
+MSG_UNKNOWN_3936
+Visionneur hexa (Binaire)
+; 
+;
+MSG_UNKNOWN_3937
+Duplique les fichiers
+; 
+;
+MSG_UNKNOWN_3938
+Lit fichier environnement
+; 
+;
+MSG_UNKNOWN_3939
+Lit fichier options
+; 
+;
+MSG_UNKNOWN_3940
+Répertoire parent
+; 
+;
+MSG_UNKNOWN_3941
+Répertoire racine
+; 
+;
+MSG_UNKNOWN_3942
+Fonction type de fichier\x00
+; 
+;
+MSG_UNKNOWN_3943
+Montre périphs et assignes
+; 
+;
+MSG_UNKNOWN_3944
+Répertoires mémorisés
+; 
+;
+MSG_UNKNOWN_3945
+Demande confirmation\x00
+; 
+;
+MSG_UNKNOWN_3946
+Imprime liste des réps
+; 
+;
+MSG_UNKNOWN_3947
+Règle quelque chose
+; 
+;
+MSG_UNKNOWN_3948
+Ferme banque de boutons
+; 
+;
+MSG_UNKNOWN_3949
+Quitte Directory Opus 5
+; 
+;
+MSG_UNKNOWN_3950
+Cache Direcory Opus
+; 
+;
+MSG_UNKNOWN_3951
+Révèle Directory Opus (si caché)\x00
+; 
+;
+MSG_UNKNOWN_3952
+Resélectionne les fichiers
+; 
+;
+MSG_UNKNOWN_3953
+Crée un lien sur fichier\x00
+; 
+;
+MSG_UNKNOWN_3954
+Crée un lien sous autre nom
+; 
+;
+MSG_UNKNOWN_3955
+Crée une assigne\x00
+; 
+;
+MSG_UNKNOWN_3956
+Configure le listeur\x00
+; 
+;
+MSG_UNKNOWN_3957
+Interpréteur de commandes
+; 
+;
+MSG_UNKNOWN_3958
+Règle en image de fond
+; 
+;
+MSG_UNKNOWN_4000
+Groupe de programmes\x00
+; 
+;
+MSG_UNKNOWN_4003
+Entrez le nom du groupe de programmes
+; 
+;
+MSG_UNKNOWN_4500
+Fichier rejeté par les filtres
+; 
+;
+MSG_UNKNOWN_4501
+Elément invalide pour Set/Query
+; 
+;
+MSG_UNKNOWN_4502
+Nom ou mot clé invalide
+; 
+;
+MSG_UNKNOWN_4503
+Trap invalide
+; 
+;
+MSG_UNKNOWN_4504
+Gestionnaire de listeur invalide\x00
+; 
+;
+MSG_UNKNOWN_4505
+Barre d'outils invalide
+; 
+;
+MSG_UNKNOWN_4506
+Chemin invalide
+; 
+;
+MSG_UNKNOWN_4507
+Objet non trouvé\x00
+; 
+;
+MSG_UNKNOWN_4508
+Pas de mémoire
+; 
+;
+MSG_UNKNOWN_4509
+Impossible d'ouvrir le listeur
+; 
+;
+MSG_UNKNOWN_4510
+Code erreur inconnu
+; 
+;
+MSG_UNKNOWN_6000
+Attention : Il est impossible de\nrécupérer ce que vous effacez.\nOkay pour effacer :\n\n
+; 
+;
+MSG_UNKNOWN_6001
+%ld groupe(s) de programmes
+; 
+;
+MSG_UNKNOWN_6005
+%ld assigne(s)
+; 
+;
+MSG_UNKNOWN_6006
+%ld groupe(s) d'objets
+; 
+;
+MSG_UNKNOWN_6007
+%ld fichier(s)
+; 
+;
+MSG_UNKNOWN_6008
+%ld répertoire(s)
+; 
+;
+MSG_UNKNOWN_7000
+Les deux fichiers semblent identiques.
+; 
+;
+MSG_UNKNOWN_7001
+Les deux fichiers ont la même version (%ld.%ld).\x00
+; 
+;
+MSG_UNKNOWN_7002
+Le nouveau fichier est une nouvelle version (%ld.%ld).
+; 
+;
+MSG_UNKNOWN_7003
+Le nouveau fichier est une ancienne version (%ld.%ld).
+; 
+;
+MSG_UNKNOWN_7004
+Le nouveau fichier est plus grand que l'ancien (de %ld octets).\n\x00
+; 
+;
+MSG_UNKNOWN_7005
+Le nouveau fichier est plus petit que l'ancien (de %ld octets).\n\x00
+; 
+;
+MSG_UNKNOWN_7006
+Les deux fichiers ont la même taille (%ld octets).\n
+; 
+;
+MSG_UNKNOWN_7007
+Le nouveau fichier est plus récent (%s).\n
+; 
+;
+MSG_UNKNOWN_7008
+Le nouveau fichier est plus vieux (%s).\n\x00
+; 
+;
+MSG_UNKNOWN_7009
+Les deux fichiers ont la même date.\n\x00
+; 
+;
+MSG_UNKNOWN_7010
+Le fichier « %s » existe et serait remplacé.\n
+; 
+;
+MSG_UNKNOWN_7011
+Le fichier « %s » existe déjà. Le remplacer ?\n\nNouveau - Taille : %7ld  Date : %19s%s\nAncien - Taille : %7ld  Date : %19s%s
+; 
+;
+MSG_UNKNOWN_7012
+Ver : %2ld.%ld
+; 
+;
+MSG_UNKNOWN_7013
+Ver : ?????
+; 
+;
+MSG_UNKNOWN_7015
+Recherche de la version...
+; 
+;
+MSG_UNKNOWN_8000
+Nom
+; 
+;
+MSG_UNKNOWN_8001
+Taille
+; 
+;
+MSG_UNKNOWN_8002
+Accès
+; 
+;
+MSG_UNKNOWN_8004
+Commentaire
+; 
+;
+MSG_UNKNOWN_8006
+Propriétaire\x00
+; 
+;
+MSG_UNKNOWN_8007
+Groupe
+; 
+;
+MSG_UNKNOWN_8008
+Réseau
+; 
+;
+MSG_UNKNOWN_8101
+Périphérique\x00
+; 
+;
+MSG_UNKNOWN_8102
+Plein
+; 
+;
+MSG_UNKNOWN_8103
+Libre
+; 
+;
+MSG_UNKNOWN_8104
+Utilisés\x00
+; 
+;
+MSG_UNKNOWN_9000
+Tapez « help list » pour avoir une liste de toutes les\ncommandes ou « help <commande> » pour la syntaxe d'une\ncommande. Entrez « quit » pour quitter le CLI .\n\nEntrez une commande interne et ses \
+options pour l'exécution.\nPour l'exécution des commandes ARexx entrez le signe « + »\navant la commande.\nEntrez « & » derrière la commande pour l'éxécution asyncrone.\n\x00
+; 
+;
+MSG_UNKNOWN_9001
+Commande sans modèle.
+; 
+;
+MSG_UNKNOWN_9002
+Tapez « Help » pour l'aide.\n\x00
+; 
+;
+MSG_UNKNOWN_9003
+Commande inconnue.
+; 
+;
+MSG_UNKNOWN_10000
+Zone de positionnement d'icônes
+; 
+;
+MSG_UNKNOWN_10001
+Cliquez et déplacez pour marquer les zones\noù les icônes peuvent être positionnés.\nCliquez « Okay » ou « Annuler » une fois fini.
+; 
+;
+MSG_UNKNOWN_10002
+AppIcônes
+; 
+;
+MSG_UNKNOWN_10003
+Disques
+; 
+;
+MSG_UNKNOWN_10004
+Listeurs/boutons\x00
+; 
+;
+MSG_UNKNOWN_10005
+Priorité\x00
+; 
+;
+MSG_UNKNOWN_10006
+Groupes
+; 
+;
+MSG_UNKNOWN_10007
+Sorties
+; 
+;
+MSG_UNKNOWN_12000
+Entrez le nom pour sauver la commande
+; 
+;
+MSG_UNKNOWN_12001
+en sauvant la commande
+; 
+;
+MSG_UNKNOWN_12002
+Editer commande...
+; 
+;
+MSG_UNKNOWN_13000
+Apparence
+; 
+;
+MSG_UNKNOWN_13001
+Bord\x00
+; 
+;
+MSG_UNKNOWN_13002
+Barre déplacement gauche\x00
+; 
+;
+MSG_UNKNOWN_13003
+Barre déplacement droite\x00
+; 
+;
+MSG_UNKNOWN_13004
+Changer l'image...
+; 
+;
+MSG_UNKNOWN_13005
+Changer le label...
+; 
+;
+MSG_UNKNOWN_13006
+Choisir l'image pour le menu démarrer
+; 
+;
+MSG_UNKNOWN_13007
+Entrer le label pour le menu démarrer
+; 
+;
+MSG_UNKNOWN_13009
+Charger menu démarrer...\x00
+; 
+;
+MSG_UNKNOWN_13010
+Choisir le menu démarrer à charger
+; 
+;
+MSG_UNKNOWN_13011
+Changer police...
+; 
+;
+MSG_UNKNOWN_13012
+Choisir la police pour le menu démarrer
+; 
+;
+MSG_UNKNOWN_13013
+Redimensionner images
+; 
+;
+MSG_UNKNOWN_13014
+Déplaceur
+; 
+;
+MSG_UNKNOWN_13015
+Sans\x00
+; 
+;
+MSG_UNKNOWN_13016
+Changer la police des labels...
+; 
+;
+MSG_UNKNOWN_13500
+Recherche de touche
+; 
+;
+MSG_UNKNOWN_13501
+_Touche :
+; 
+;
+MSG_UNKNOWN_13502
+Trouvé :\x00
+; 
+;
+MSG_UNKNOWN_13600
+Touche invalide !
+; 
+;
+MSG_UNKNOWN_13601
+Pas de correspondance !
+; 
+;
+MSG_UNKNOWN_13602
+Correspondance dans une banque de boutons.
+; 
+;
+MSG_UNKNOWN_13603
+Correspondance dans la barre d'outils listeur.
+; 
+;
+MSG_UNKNOWN_13604
+Correspondance dans le menu listeur.\x00
+; 
+;
+MSG_UNKNOWN_13605
+Correspondance dans le menu utilisateur.\x00
+; 
+;
+MSG_UNKNOWN_13606
+Correspondance dans le menu démarrer.
+; 
+;
+MSG_UNKNOWN_13607
+Correspondance dans les raccourcis.
+; 
+;
+MSG_UNKNOWN_13608
+Correspondance dans les scripts.\x00
+; 

--- a/catalogs/français/dopuslib.ct
+++ b/catalogs/français/dopuslib.ct
@@ -1,0 +1,79 @@
+## version $VER: DOpusLib.catalog 5.61 (08.07.1997)
+## codeset 0
+## language français
+; ************************************************* 
+; Catalog description file for dopus5.library
+; Copyright © 1995 Jonathan Potter
+; ************************************************* 
+;
+;
+; Generic strings
+;
+MSG_OK
+Okay\x00
+; OK
+;
+MSG_SELECT_FILE
+Choisir un fichier
+; Select File
+;
+MSG_SELECT_DIRECTORY
+Choisir un répertoire
+; Select Directory
+;
+MSG_SELECT_FONT
+Choisir police
+; Select Font
+;
+MSG_FONT_DRAWMODE
+Mode :
+; Mode:
+;
+MSG_FONT_TEXT
+Texte
+; Text
+;
+MSG_FONT_FIELD_TEXT
+Texte + champs
+; Text+Field
+;
+MSG_SIZE_FIT
+
+; 9999%%
+;
+MSG_SIZE
+
+; %ld%%
+;
+MSG_ABORT
+Annuler
+; Abort
+;
+MSG_FILE_FIT
+9999 sur 9999
+; 9999 of 9999
+;
+MSG_FILE
+%ld sur %ld
+; %ld of %ld
+;
+MSG_DIRECTORY_OPUS_REQUEST
+Requête Directory Opus
+; Directory Opus Request
+;
+;
+;
+; Error messages
+;
+MSG_UNABLE_TO_OPEN_TOOL
+Impossible d'ouvrir l'outil « %s »
+; Unable to open your tool '%s'
+;
+MSG_SICK_OF_WAITING
+Opus est agacé d'attendre le retour de\n« %s »\nAttendre encore un peu ?
+; Opus is sick of waiting for '%s' to return.\nWait some more?
+;
+MSG_WAIT_CANCEL
+Attendre|Annuler\x00
+; Wait|Cancel
+;

--- a/catalogs/français/filetype.ct
+++ b/catalogs/français/filetype.ct
@@ -1,0 +1,269 @@
+## version $VER: FileType.catalog 5.61 (08.07.1997)
+## codeset 0
+## language français
+; ************************************************* 
+; Catalog description file for creator.module
+; ************************************************* 
+;
+;
+MSG_FIND_DESC
+Trouve le type d'un fichier
+; Find filetype for a file
+;
+MSG_FIND_TITLE
+Chercheur de type de fichier\x00
+; Filetype Finder
+;
+MSG_FIND_PRI
+
+; Pri
+;
+MSG_FIND_ID
+
+; ID
+;
+MSG_FIND_FILETYPE
+Type de fichier
+; Filetype
+;
+MSG_FIND_FILE
+Fichier...
+; File...
+;
+MSG_FIND_USE
+_Utiliser
+; _Use
+;
+MSG_FIND_INSTALL
+_Installer
+; _Install
+;
+MSG_FIND_CREATE
+_Créer
+; _Create
+;
+MSG_FIND_EDIT
+_Editer
+; _Edit
+;
+MSG_FIND_CANCEL
+_Annuler\x00
+; C_ancel
+;
+MSG_FIND_SCANNING
+Examen des types de fichiers...
+; Scanning filetypes...
+;
+MSG_FIND_MATCHING
+Types de fichiers correspondants...
+; Matching filetypes...
+;
+MSG_NONE_FOUND_1
+Pour le fichier sélectionné
+; No filetype has been found that
+;
+MSG_NONE_FOUND_2
+aucun type de fichier n'a été trouvé\x00
+; matches the selected file. Do you
+;
+MSG_NONE_FOUND_3
+Voulez vous créer un nouveau\x00
+; wish to create a new filetype for
+;
+MSG_NONE_FOUND_4
+type de fichier pour le fichier ?
+; this file?
+;
+MSG_NONE_FOUND_5
+
+; 
+;
+MSG_NONE_FOUND_6
+
+; 
+;
+MSG_NONE_FOUND_7
+
+; 
+;
+MSG_STORED_FOUND_1
+Aucun type de fichier installé ne
+; No installed filetype matches the
+;
+MSG_STORED_FOUND_2
+correspond au fichier sélectionné. Dans
+; selected file. However, there is
+;
+MSG_STORED_FOUND_3
+la réserve, cependant, un y correspond.
+; a filetype in storage which does match.
+;
+MSG_STORED_FOUND_4
+Voulez vous l'installer maintenant
+; Do you wish to install this filetype 
+;
+MSG_STORED_FOUND_5
+ou en créer un nouveau ?\x00
+; now or create a new one?
+;
+MSG_STORED_FOUND_6
+
+; 
+;
+MSG_STORED_FOUND_7
+
+; 
+;
+MSG_BETTER_FOUND_1
+Dans la réserve se trouve un type
+; There is a filetype in storage which
+;
+MSG_BETTER_FOUND_2
+de fichier pour le fichier choisit,
+; matches the selected file and has a
+;
+MSG_BETTER_FOUND_3
+ayant une  priorité supérieure,
+; higher priority than the currently
+;
+MSG_BETTER_FOUND_4
+au type fichier installé. Voulez vous
+; installed filetype for this file. Do
+;
+MSG_BETTER_FOUND_5
+l'utiliser temporairement ou en créer
+; you wish to use the current filetype,
+;
+MSG_BETTER_FOUND_6
+un nouveau ?\x00
+; install the stored filetype, or create
+;
+MSG_BETTER_FOUND_7
+\x00
+; a new one?
+;
+MSG_INSTALLED_FOUND_1
+Il y un type de fichier installé\x00
+; There is a filetype installed
+;
+MSG_INSTALLED_FOUND_2
+correspondant au fichier choisit.
+; which matches the selected file.
+;
+MSG_INSTALLED_FOUND_3
+Voulez vous utliser ce type de fichier
+; Do you wish to use this Filetype
+;
+MSG_INSTALLED_FOUND_4
+ou en créer un nouveau ?\x00
+; or create a new one?
+;
+MSG_INSTALLED_FOUND_5
+
+; 
+;
+MSG_INSTALLED_FOUND_6
+
+; 
+;
+MSG_INSTALLED_FOUND_7
+
+; 
+;
+;
+;	CREATOR
+;
+;
+;
+MSG_CREATE_DESC
+Créer type de fichier
+; Create new filetype
+;
+MSG_CREATE_TITLE
+Créateur de type de fichier
+; Filetype Creator
+;
+MSG_CREATE_FILES
+Fichiers...
+; Files...
+;
+MSG_CREATE_ADD
+_Ajouter\x00
+; _Add
+;
+MSG_CREATE_DELETE
+_Effacer\x00
+; _Delete
+;
+MSG_CREATE_CLEAR
+_Vider
+; _Clear
+;
+MSG_CREATE_FILETYPE
+Type de fichier...
+; Filetype...
+;
+MSG_CREATE_NAME
+   _Nom :
+;  _Name:
+;
+MSG_CREATE_IFF
+   _IFF :
+;   _IFF:
+;
+MSG_CREATE_GROUP
+_Groupe :
+; _Group:
+;
+MSG_CREATE_ID
+    I_D :
+;    I_D:
+;
+MSG_CREATE_BYTES
+_Octets :
+; _Bytes:
+;
+MSG_CREATE_CASE
+Casse
+; Case
+;
+MSG_CREATE_NOCASE
+Sans casse
+; No Case
+;
+MSG_CREATE_EDIT
+_Editer
+; _Edit
+;
+MSG_CREATE_SAVE
+_Sauver
+; _Save
+;
+MSG_CREATE_CANCEL
+_Annuler\x00
+; _Cancel
+;
+MSG_CREATE_ADD_FILE
+Ajouter un fichier...
+; Add a file...
+;
+MSG_CREATE_WARN_EDITED
+ATTENTION\n\nVous avez utilisé l'éditeur.\nSi vous continuez, les changements\nseront perdus...
+; WARNING\n\nYou have used the editor.\nIf you continue your changes will be lost...
+;
+MSG_CREATE_CONTINUE_CANCEL
+Continuer|Annuler
+; Continue|Cancel
+;
+;
+;
+;
+;
+MSG_REPLACE_CANCEL
+Remplacer|Annuler
+; Replace|Cancel
+;
+MSG_FILETYPE_EXISTS
+Le type de fichier « %s »\nexiste. Voulez vous le remplacer ?\x00
+; Filetype '%s' exists.\nDo you wish to replace it?
+;

--- a/catalogs/français/font.ct
+++ b/catalogs/français/font.ct
@@ -1,0 +1,68 @@
+## version $VER: ViewFont.catalog 5.61 (08.07.1997)
+## codeset 0
+## language français
+; ************************************************* 
+; Catalog description file for font.module
+; ************************************************* 
+;
+;
+MSG_FONT_TITLE
+Afficheur de police
+; Font Viewer
+;
+MSG_FONT_FONT
+_Police
+; _Font
+;
+MSG_FONT_SIZE
+_Taille
+; _Size
+;
+MSG_FONT_PRINT
+_Imprimer
+; _Print
+;
+MSG_VIEWFONT_DESC
+Affiche les polices
+; View a font
+;
+MSG_FONT_BOLD
+_G
+; _B
+;
+MSG_FONT_ITALIC
+_I
+; _I
+;
+MSG_FONT_ULINE
+_S
+; _U
+;
+MSG_FONT_SELECT
+Choisir une police
+; Select Font
+;
+MSG_OK
+Okay
+; Ok
+;
+MSG_MENU_PROJECT
+Projet
+; Project
+;
+MSG_MENU_OPEN_FONT
+Ouvrir police...
+; Open Font...
+;
+MSG_MENU_SAVE_SETTINGS
+Sauver réglages
+; Save Settings
+;
+MSG_MENU_QUIT
+Quitter
+; Quit
+;
+MSG_MENU_ABOUT
+A propos...
+; About...
+;

--- a/catalogs/français/format.ct
+++ b/catalogs/français/format.ct
@@ -1,0 +1,140 @@
+## version $VER: Format.catalog 5.61 (08.07.1997)
+## codeset 0
+## language français
+; ************************************************* 
+; Catalog description file for format.module
+; ************************************************* 
+;
+;
+MSG_FORMAT_TITLE
+Formatage de disque
+; Format
+;
+MSG_FORMAT_FORMAT
+_Formater
+; _Format
+;
+MSG_FORMAT_QUICK_FORMAT
+_Rapide
+; _Quick Format
+;
+MSG_FORMAT_CANCEL
+_Annuler\x00
+; _Cancel
+;
+MSG_FORMAT_NAME
+_Nom\x00
+; _Name
+;
+MSG_FORMAT_FFS
+Fa_st File System
+; F_ast File System
+;
+MSG_FORMAT_INTERNATIONAL
+Mode _International
+; _International Mode
+;
+MSG_FORMAT_CACHING
+_Répertoire rapide
+; _Directory Caching
+;
+MSG_FORMAT_TRASHCAN
+Avec _poubelle
+; _Put Trashcan
+;
+MSG_FORMAT_INSTALL
+_Démarrable
+; _Make Bootable
+;
+MSG_FORMAT_VERIFY
+_Vérifier
+; _Verify
+;
+MSG_FORMAT_DEFAULT_NAME
+Vide\x00
+; Empty
+;
+MSG_FORMAT_STATUS
+%ld pistes, %ld octets/piste, %s\x00
+; %ld tracks, %ld bytes/trk, %s
+;
+MSG_OPENING_DEVICE
+Ouverture du périphérique...\x00
+; Opening device...
+;
+MSG_CHECKING_DISK
+Vérification du disque...
+; Checking disk...
+;
+MSG_CANT_OPEN_DEVICE
+Impossible d'ouvrir le périphérique !
+; Unable to open device!
+;
+MSG_NO_DISK_PRESENT
+Pas de disque présent dans le lecteur !
+; No disk present in drive!
+;
+MSG_DISK_WRITE_PROTECTED
+Le disque protegé en écriture !
+; Disk is write-protected!
+;
+MSG_RETRY_CANCEL
+Réessayer|Annuler
+; Retry|Cancel
+;
+MSG_PROCEED_CANCEL
+Continuer|Annuler
+; Proceed|Cancel
+;
+MSG_DISK_NOT_BLANK
+Le disque dans le lecteur %s n'est pas vide !\n« %s » contient %s de données.\nToutes les données seront effacées.\nChoisir « Continuer » pour confirmer.
+; Disk in drive %s is not blank!\nVolume '%s' contains %s.\nAll data will be erased.\nChoose Proceed to continue.
+;
+MSG_ABORTED
+Annulé.
+; Aborted.
+;
+MSG_FORMAT_INITIALISING
+Initialisation du disque...
+; Initialising disk...
+;
+MSG_FORMAT_FORMATTING
+Formatage en cours...
+; Formatting...
+;
+;
+MSG_UNKNOWN_1025
+Erreur de formatage sur la piste %ld.
+; 
+;
+MSG_UNKNOWN_1026
+Erreur de vérification sur la piste %ld.\x00
+; 
+;
+MSG_UNKNOWN_1027
+Formatage réussi !
+; 
+;
+MSG_UNKNOWN_1028
+Le formatage a échoué.
+; 
+;
+MSG_UNKNOWN_1029
+Mise au point...\x00
+; 
+;
+MSG_UNKNOWN_1030
+Nettoyage...\x00
+; 
+;
+MSG_UNKNOWN_1031
+Création de la poubelle...
+; 
+;
+MSG_UNKNOWN_1032
+Installation du bloc d'amorce...\x00
+; 
+;
+MSG_UNKNOWN_1033
+Formate les disques
+; 

--- a/catalogs/français/ftp.ct
+++ b/catalogs/français/ftp.ct
@@ -1,0 +1,1404 @@
+## version $VER: FTP.catalog 5.61 (08.07.97) par Georges 'Melkor' Goncalves & Kersten 'Emmy' Emmrich
+## codeset 0
+## language français
+; ************************************************* 
+; Catalog description file for ftp.module
+; ************************************************* 
+;
+; Thse are the descriptions of the ftp commands
+;
+;
+MSG_FTP_ADDRBOOK
+Carnet d'adresses FTP
+; Show FTP address book
+;
+MSG_FTP_CONNECT_SITE
+Se connecte au site
+; Connect to FTP site
+;
+OBSOLETE001
+Change de répertoire\x00
+; 
+;
+OBSOLETE002
+Copie les fichiers
+; 
+;
+OBSOLETE003
+Renomme les fichiers\x00
+; 
+;
+OBSOLETE004
+Efface les fichiers
+; 
+;
+MSG_FTP_COMMAND
+Envoie des commandes\x00
+; Send command to FTP site
+;
+MSG_FTP_SETVAR
+Definit la variable FTP
+; Set FTP variable
+;
+MSG_FTP_QUIT
+Quitte OpusFTP
+; Quit OpusFTP
+;
+; These are requester options sererated by bars "|"
+;
+MSG_FTP_OKAY
+Okay\x00
+; OK
+;
+MSG_FTP_CANCEL
+Annuler
+; Cancel
+;
+OBSOLETE005
+Okay|Annuler\x00
+; 
+;
+OBSOLETE006
+Okay|Anonyme|Annuler\x00
+; 
+;
+OBSOLETE007
+ Remplacer|Passer|Continuer|Annuler
+; 
+;
+OBSOLETE008
+Remplacer|Remplacer tout|Passer|Passer tout|Annuler
+; 
+;
+OBSOLETE009
+Un fichier|Tous|Annuler
+; 
+;
+OBSOLETE010
+Renommer|Annuler\x00
+; 
+;
+OBSOLETE011
+Continuer|Effacer tout|Annuler
+; 
+;
+OBSOLETE012
+
+; 
+;
+OBSOLETE013
+
+; 
+;
+OBSOLETE014
+Carnet d'adresses FTP
+; 
+;
+MSG_FTP_CONNECTING
+Connexion...\x00
+; Connecting...
+;
+MSG_FTP_LOGGING_IN
+Entrée en
+; Logging in as
+;
+MSG_FTP_ENTER_HOSTNAME
+Entrez le nom de l'hôte
+; Enter host name
+;
+MSG_FTP_ENTER_USERNAME
+Entrez le nom utilisateur
+; Enter user name
+;
+MSG_FTP_ENTER_PASSWORD
+Entrez le mot de passe
+; Enter password
+;
+MSG_FTP_CANT_LOG_IN_TO
+Impossible d'entrer dans\x00
+; Cannot log in to
+;
+MSG_FTP_NOT_AVAILABLE
+n'est plus disponible
+; no longer available
+;
+;
+;
+OBSOLETE015
+copie
+; 
+;
+MSG_FTP_ENTER_NEW_FILENAME
+Entrez le nouveau nom
+; Enter new filename.
+;
+OBSOLETE016
+Récupération des fichiers...\x00
+; 
+;
+OBSOLETE017
+Stockage des fichiers...\x00
+; 
+;
+;
+;
+MSG_FTP_ENTER_FILENAME_TO
+Entrez le nom de fichier pour
+; Enter filename to
+;
+MSG_FTP_SKIP
+Passer
+; Skip
+;
+MSG_FTP_REPLACE
+Remplacer
+; Replace
+;
+MSG_FTP_RESUME
+Continuer
+; Resume
+;
+;
+;	Replace requester
+;
+;
+MSG_FTP_FILE
+Fichier
+; File
+;
+MSG_FTP_ALREADY_EXISTS
+existe déjà
+; already exists
+;
+MSG_FTP_NEWSIZE
+Nouv - Taille
+; New - Size
+;
+MSG_FTP_OLDSIZE
+Anc. - Taille
+; Old - Size
+;
+MSG_FTP_DATE
+
+; Date
+;
+OBSOLETE018
+Voulez vous le remplacer\nou continuer le transfer ?
+; 
+;
+MSG_FTP_REPLACE_IT
+Le remplacer ?
+; Replace it?
+;
+OBSOLETE019
+tous les fichiers sélectionnés ?\x00
+; 
+;
+;
+;
+MSG_FTP_XFER_BYTES
+octets
+; bytes
+;
+MSG_FTP_ENTER_DIRNAME
+Entrez le nom du répertoire
+; Enter directory name
+;
+MSG_FTP_MAKEDIR_ERROR
+Erreur en créant le répertoire
+; An error occured creating the directory
+;
+OBSOLETE020
+renommer\x00
+; 
+;
+MSG_FTP_RENAME_ERROR
+Erreur en renommant l'entrée\x00
+; An error occured renaming the entry
+;
+;
+; (The delete requester)
+;
+OBSOLETE021
+effacer
+; 
+;
+MSG_FTP_WARNING_CANT_GET_BACK
+Attention : Il est impossible de\x00
+; Warning: you cannot get back
+;
+MSG_FTP_OK_TO_DELETE
+récupérer ce que vous effacez !
+; what you delete! OK to delete
+;
+MSG_FTP_FILES_AND
+Okay pour effacer le(s) fichier(s)
+; file(s) and
+;
+OBSOLETE022
+et répertoire(s) (si vide(s))
+; 
+;
+MSG_FTP_FROM
+de
+; from
+;
+OBSOLETE023
+Erreur en effaçant l'entrée
+; 
+;
+;
+MSG_FTP_RETRIEVING_FILE
+Récupération du fichier...
+; Retrieving file...
+;
+OBSOLETE024
+Listage du répertoire...\x00
+; 
+;
+MSG_FTP_CHANGING_DIR
+Changement de répertoire...
+; Changing directory...
+;
+OBSOLETE025
+Entrez le répertoire où aller
+; 
+;
+MSG_FTP_PATH_NOT_FOUND
+Chemin non trouvé sur le site FTP
+; Path not found on FTP site
+;
+MSG_FTP_CMD_TO_SEND
+Entrez la commande FTP a envoyer\x00
+; Enter FTP command to send
+;
+MSG_FTP_SENDING_CMD
+Envoi de la commande FTP...
+; Sending FTP command...
+;
+MSG_FTP_LOCAL_VAR
+Nouvelle valeur de la variable locale
+; Enter new value for local variable
+;
+MSG_FTP_DELETING
+Effacement en cours...
+; Deleting...
+;
+MSG_FTP_RENAMING
+Renomination...
+; Renaming...
+;
+;
+; Error messages
+;
+MSG_FTP_COULD_NOT_CONNECT
+(Impossible de se connecter)\x00
+; (Could not connect)
+;
+MSG_FTP_USERNAME_FAILED
+(Le nom utilisateur a échoué)
+; (User name failed)
+;
+MSG_FTP_PASSWORD_FAILED
+(Le mot de passe a échoué)
+; (Password failed)
+;
+MSG_FTP_SERVER_CLOSED_CONN
+(Le serveur a clôt la connexion)\x00
+; (Server closed connection)
+;
+MSG_FTP_NO_ERR
+(Pas d'erreur détectée)
+; (No error detected)
+;
+MSG_FTP_INT_SYS_CALL
+(Appel système interrompu)
+; (Interrupted system call)
+;
+MSG_FTP_PERMISSION_DENIED
+(Permission refusée)\x00
+; (Permission denied)
+;
+MSG_FTP_PROTO_NOT_SUPP
+(Protocole non supporté)\x00
+; (Protocol not supported)
+;
+MSG_FTP_CANT_ASSIGN_ADDR
+(Impossible d'assigner l'adresse demandée)
+; (Cannot assign requested address)
+;
+MSG_FTP_CONN_RESET_PEER
+(Connexion réinitialisée à distance)\x00
+; (Connection reset by peer)
+;
+MSG_FTP_TIMEOUT
+(Connexion arrivée à échéance)
+; (Connection timed out)
+;
+MSG_FTP_CONN_REFUSED
+(Connexion refusée)
+; (Connection refused)
+;
+MSG_FTP_NO_ROUTE
+(Pas de route vers l'hôte)
+; (No route to host)
+;
+MSG_ERR_XX
+(Erreur xx)
+; (Error xx)
+;
+;
+;
+MSG_MAIN_NEED_TCPIP
+Vous devez avoir une pile TCP/IP\ncomme AmiTCP, AS225, INet ou MLink\nen fonction pour utiliser OpusFTP
+; You must have a TCP/IP stack\nsuch as AmiTCP, AS225, INet,\nMiami, MLink, or TermiteTCP\nrunning to use\nOpusFTP
+;
+; (The next two lines make up a single string "The ??? command...")
+MSG_MAIN_THE
+La commande
+; The
+;
+MSG_MAIN_CMD_NOT_SUPP
+\nn'est pas actuellement\nsupportée par OpusFTP
+; command\nis not currently supported\nby OpusFTP
+;
+;
+; ************************************************* 
+; Catalog description file for ftp gui
+; ************************************************* 
+;
+;
+MSG_FTP_TITLE
+Sites FTP Opus
+; Opus FTP Sites
+;
+MSG_SITE_DETAILS
+Détails de site
+; Site Details
+;
+MSG_OPTIONS_TITLE
+Options OpusFTP
+; Opus FTP Options
+;
+MSG_FTP_SITES
+Sites FTP...\x00
+; FTP Sites...
+;
+MSG_SITE_NAME
+Nom
+; Name
+;
+MSG_SITE_HOST
+Hôte\x00
+; Host
+;
+MSG_SITE_PORT
+
+; Port
+;
+MSG_SITE_ANON
+Anonyme
+; Anon
+;
+MSG_FTP_CONNECT
+_Connecter
+; Connec_t
+;
+MSG_FTP_SAVE
+_Sauver
+; _Save
+;
+MSG_FTP_EDIT
+_Editer
+; _Edit
+;
+MSG_FTP_NEW
+_Nouveau\x00
+; Ne_w
+;
+MSG_DELETE
+E_ffacer\x00
+; _Del
+;
+MSG_OPTIONS
+
+; _Options
+;
+MSG_FTP_OK
+_Okay
+; _Ok
+;
+MSG_FTP_CANCEL_ULINE
+_Annuler\x00
+; _Cancel
+;
+MSG_EDIT_NAME
+_Nom\x00
+; _Name
+;
+MSG_EDIT_HOST
+_Hôte
+; _Host
+;
+MSG_EDIT_PORT
+P_ort
+; _Port
+;
+MSG_EDIT_ANON
+A_non
+; _Anon
+;
+MSG_EDIT_USER
+_Util.
+; _User
+;
+MSG_EDIT_PASSWORD
+_Pass
+; Pa_ss
+;
+MSG_EDIT_DIR
+_Rép.
+; _Dir
+;
+OBSOLETE26
+_Pass anon
+; 
+;
+MSG_LOG_FILE
+_Fichier\x00
+; Log _File
+;
+MSG_LOG_ON
+_Rapport\x00
+; _Log
+;
+MSG_UPDATE
+A_ctualiser
+; _Update
+;
+MSG_DEBUG
+_Débogue\x00
+; _Debug
+;
+MSG_TIMEOUT
+_Délai
+; _Timeout
+;
+MSG_SHOW_INDEX
+_Index
+; Inde_x
+;
+MSG_AUTO_INDEX
+A_uto
+; Aut_o
+;
+MSG_INDEX_SIZE
+_Taille max
+; _Max Size
+;
+MSG_SECONDS
+
+; sec
+;
+MSG_KILOBYTES
+Ko
+; kb
+;
+MSG_SEND_NOOP
+_NOOPs
+; NOOPs
+;
+MSG_BADSITE
+Détails de site invalides.\nVous devez entrer une IP ou adresse d'hôte.
+; Invalid Site Details\nYou must enter a Host IP or Address.
+;
+MSG_BADVER
+Ce module OpusFTP requiers\nDOpus 5.51 ou supérieur !\x00
+; This OpusFTP module requires\nDOpus version 5.51 or higher!
+;
+MSG_QUERYSAVE
+Vous avez modifié la config FTP et ne\nl'avez pas sauvée. Voulez vous le faire ?
+; You have modified the FTP config and not\nsaved it. Would you like to?
+;
+MSG_FTP_USE
+_Utiliser
+; _Use
+;
+MSG_QUERYINDEX
+Fichier « %s » de taille %ld %s trouvé.\nLe récupérer et mettre à jour les commentaires ?\x00
+; Found file %s of size %ld %s.\nFetch it and update file comments?
+;
+MSG_BADHASH
+Désolé, OpusFTP ne peut manipuler les\nfichiers commençant par le caractère '#'.
+; Sorry, OpusFTP cannot handle files\nbeginning with the '#' character.
+;
+MSG_FTP_DOS_ERROR
+Erreur DOS
+; DOS error
+;
+OBSOLETE027
+Erreur d'écriture disque.\nDisque plein ?\x00
+; 
+;
+MSG_NO_LOCALHOST
+Désolé, impossible de transférer les fichiers\nen utilisant les hôtes locaux @127... !
+; Site to site transfer is not possible using localhost.\nPlease use the full address instead.
+;
+OBSOLETE028
+Transfer de fichier en cours...
+; 
+;
+OBSOLETE029
+Des répertoires ont été sélectionnés.\nLa copie récursive n'est pas supportée.
+; 
+;
+;
+;	New for post-magellan version of ftp.module
+;
+;	New built-in FTP commands
+;
+MSG_FTP_FTPADD
+
+; Add site to FTP address book
+;
+;	Requester buttons
+;
+MSG_FTP_YES
+
+; Yes
+;
+MSG_FTP_NO
+
+; No
+;
+MSG_FTP_KEEP
+
+; Keep
+;
+MSG_FTP_RECONNECT
+
+; Reconnect
+;
+MSG_FTP_REPLACEALL
+
+; Replace All
+;
+MSG_FTP_SKIPALL
+
+; Skip All
+;
+MSG_FTP_PROCEED
+
+; Proceed
+;
+MSG_DELETE_FILES
+
+; Delete
+;
+MSG_FTP_DELETEALL
+
+; Delete All
+;
+MSG_FTP_ANONYMOUS
+
+; Anonymous
+;
+MSG_FTP_RENAME_UCASE
+
+; Rename
+;
+MSG_FTP_COPY_UCASE
+
+; Copy
+;
+MSG_MOVE
+
+; Move
+;
+MSG_TRY_AGAIN
+
+; Try Again
+;
+MSG_ABORT
+
+; Abort
+;
+;	Progress bar messages
+;
+MSG_FTP_COPYING
+
+; Copying...
+;
+MSG_FTP_MOVING
+
+; Moving...
+;
+MSG_FTP_SCANNING_DIRS
+
+; Scanning directories...
+;
+MSG_FTP_SETTING_PROT
+
+; Setting protections...
+;
+MSG_READING_DIR
+
+; Reading directory...
+;
+;	Delete confirmation requesters
+;
+MSG_FTP_DRAWERS
+
+; drawer(s) (and their contents)
+;
+MSG_DELETE_DIRS
+
+; is a directory.\nProcede with delete operation?
+;
+;	Recursive confirmation requester
+;
+MSG_ACT_ON
+
+; Act on
+;
+MSG_FILES_IN_SUBDIRS
+
+; files in sub-directories?
+;
+;	Transfer progress info line
+;
+MSG_FROM
+
+; From
+;
+MSG_TO
+
+; to
+;
+;	Replace requesters
+;
+MSG_DESTINATION
+
+; Destination
+;
+MSG_IS_A_FILE
+
+; is a file
+;
+MSG_IS_A_DIR
+
+; is a directory
+;
+MSG_FTP_WOULD_BE_REPLACED
+
+; exists and would be replaced.
+;
+MSG_FTP_APPEAR_SAME
+
+; The two files appear to be the same.
+;
+MSG_IS_LONGER
+
+; is longer than the old version.
+;
+MSG_RESUME_XFER
+
+; Resume transfer?
+;
+;	More errors
+;
+MSG_NET_DOWN
+
+; (Network is down)
+;
+MSG_NET_UNREACH
+
+; (Network is unreachable)
+;
+MSG_CONN_ABORTED
+
+; (Software caused connection abort)
+;
+MSG_HOST_DOWN
+
+; (Host is down)
+;
+MSG_SITE_NOT_FOUND
+
+; (Site not found)
+;
+MSG_FTP_LOST_TIMEOUT
+
+; (Server connection timed out)
+;
+MSG_FTP_LOST_UNEXPECT
+
+; (Unexpected error ocurred)
+;
+;	Connect / login progress messages
+;
+MSG_LOOKING_UP
+
+; Looking up host...
+;
+MSG_HOST_FOUND
+
+; Host found, connecting...
+;
+MSG_READING_STARTUP
+
+; Connected, reading startup message...
+;
+MSG_CONNECT_RETRY
+
+; Connect retry %ld/%ld in %ld seconds...
+;
+MSG_QUERY_SYSTYPE
+
+; Querying FTP server type...
+;
+MSG_ENABLE_NT
+
+; Enabling Windows NT native mode...
+;
+MSG_BINARY_MODE
+
+; Setting binary transfer mode...
+;
+MSG_QUERY_PATH
+
+; Querying initial path...
+;
+MSG_INITIAL_DIR
+
+; Changing to initial path...
+;
+;	More GUI
+;
+MSG_RETRY_CONNECT
+
+; R_etry
+;
+MSG_RETRY_COUNT
+
+; C_ount
+;
+MSG_RETRY_TIME
+
+; Tim_e
+;
+MSG_DIR_PROGRESS
+
+; _Progress
+;
+;
+;
+MSG_FTP_GETPUT_NO_PASV
+
+; Neither site supports passive transfers.\nSite to site transfer is not possible.
+;
+MSG_FTP_LOGIN_FAILED
+
+; Login unsuccessful.
+;
+MSG_FTP_CHANGE_USERPASS
+
+; Do you wish to alter the user name\nand password?
+;
+MSG_RESUME_FAILURE
+
+; This FTP server does not support the resume feature.\nThe old file will be replaced.
+;
+MSG_CONSOLE_TITLE
+
+; Directory Opus Magellan FTP
+;
+MSG_FTP_CHMOD_ERROR
+
+; An error occured setting the protection flags
+;
+;*********************************************
+MSG_FTP_SUB_DETAILS
+
+; Details
+;
+MSG_FTP_NAME
+
+; Name
+;
+MSG_FTP_HOST
+
+; Host
+;
+MSG_FTP_ANONPASS
+
+; Anon
+;
+MSG_FTP_PORT
+
+; Port
+;
+MSG_FTP_USER
+
+; User
+;
+MSG_FTP_PASS
+
+; Pass
+;
+MSG_FTP_DIR
+
+; Dir
+;
+MSG_FTP_SUB_RECONNECTION
+
+; Reconnect
+;
+MSG_FTP_OPTIONS_ENABLE_RETRY
+
+; Enable Retry
+;
+MSG_FTP_OPTIONS_RETRY_COUNT
+
+; Retry Count
+;
+MSG_FTP_OPTIONS_RETRY_DELAY
+
+; Retry Delay
+;
+MSG_FTP_OPTIONS_ENABLE_RETRY_LOST
+
+; Auto Reconnect
+;
+MSG_FTP_OPTIONS_NOOPS
+
+; Send NOOPs (Idle)
+;
+MSG_FTP_NETWORK_TIMEOUT
+
+; Network Timeout (Secs)
+;
+MSG_FTP_LIST_UPDATE
+
+; List Update (Secs)
+;
+MSG_FTP_SUB_MISC
+
+; Miscellaneous
+;
+MSG_FTP_PROGRESS_WINDOW
+
+; Progress Windows (CD & List)
+;
+MSG_FTP_LOGICAL_LINKS
+
+; Logical Parent Dir
+;
+MSG_FTP_KEEP_LAST_DIR
+
+; Keep last Directory
+;
+MSG_FTP_SUB_SCRIPTS
+
+; Scripts
+;
+MSG_FTP_TEXT_SCRIPTS
+
+; Custom FTP Scripts...
+;
+MSG_FTP_SCRIPT_CONNECT_FAIL
+
+; Connect Fail
+;
+MSG_FTP_SCRIPT_CONNECT_SUCCESS
+
+; Connect Success
+;
+MSG_FTP_SCRIPT_COPY_SUCCESS
+
+; Copy Success
+;
+MSG_FTP_SCRIPT_COPY_FAIL
+
+; Copy Fail
+;
+MSG_FTP_SCRIPT_ERROR
+
+; Error
+;
+MSG_FTP_SCRIPT_CLOSE
+
+; Close Connection
+;
+MSG_FTP_SCRIPT_TIME
+
+; Activation Time (Secs)
+;
+MSG_FTP_SUB_INDEX
+
+; Index
+;
+MSG_FTP_INDEX
+
+; Download Index
+;
+MSG_FTP_AUTO_DOWNLOAD
+
+; Auto Download
+;
+MSG_FTP_AUTO_DOWNLOAD_SIZE
+
+; Max Size (Kb)
+;
+MSG_ADD
+
+; Add
+;
+MSG_SORT
+
+; So_rt
+;
+MSG_DEFAULT
+
+; Default
+;
+MSG_RESET_TO_DEFAULT
+
+; Reset to Defaults
+;
+MSG_RESET_TO_SYSTEM
+
+; Reset FTP Defaults
+;
+MSG_CUSTOM_OPTIONS
+
+; Custom Options
+;
+MSG_DEFAULT_OPTIONS
+
+; Default Options
+;
+MSG_ADVANCED_SETTINGS
+
+; Advanced Settings
+;
+MSG_SET_CUSTOM
+
+; Set Custo_m
+;
+MSG_LOG_ENABLE
+
+; Enable Log
+;
+MSG_FTP_LOG_DEBUG
+
+; Enable Debug
+;
+MSG_FTP_GLOBAL
+
+; Global
+;
+MSG_FTP_GLOBAL_SETTINGS
+
+; Global Settings
+;
+MSG_FTP_PASSIVE_TRANSFER
+
+; Passive Transfers
+;
+MSG_FTP_SPECIAL_DIR
+
+; Special Directory Names
+;
+MSG_FTP_LINKS
+
+; Links...
+;
+MSG_FTP_UNK_LINKS
+
+; Unknown
+;
+MSG_FTP_UNK_LINKS_FILE
+
+; As File
+;
+MSG_FTP_UNK_LINKS_DIR
+
+; As Directory
+;
+MSG_FTP_SUB_LISTER
+
+; Lister Display
+;
+MSG_FTP_TEXT_LISTER
+
+; FTP Lister Settings...
+;
+MSG_FTP_SUB_DISPLAY
+
+; Display
+;
+MSG_FORMAT_SET
+
+; Set Custom..
+;
+MSG_DEFAULT_FORMAT
+
+; FTP Lister Format...
+;
+MSG_LISTER_TOOLBAR
+
+; Toolbar:
+;
+MSG_SHOW_DIR_MSG
+
+; Show Directory Messages
+;
+MSG_SHOW_STARTUP_MSG
+
+; Show Startup Messages
+;
+MSG_TRANSFER_PPOGRESS
+
+; File Transfer Progress Display
+;
+MSG_TRANSFER_DETAILS
+
+; Show Transfer Details
+;
+MSG_REPLACE
+
+; Replace
+;
+MSG_REPLACE_ALWAYS
+
+; Always
+;
+MSG_REPLACE_NEVER
+
+; Never
+;
+MSG_REPLACE_ASK
+
+; Ask
+;
+MSG_FTP_SUB_COPYFLAGS
+
+; Copy
+;
+MSG_FTP_SUB_COPYATTR
+
+; Copy Attributes
+;
+MSG_FTP_TEXT_COPY
+
+; Options
+;
+MSG_FTP_TEXT_COPY_ATTRIBUTES
+
+; Attributes
+;
+MSG_COPY_DEFAULT
+
+; None
+;
+MSG_COPY_UPDATE
+
+; Update
+;
+MSG_COPY_NEWER
+
+; Newer
+;
+MSG_COPY_FLAGS
+
+; Copy Flags
+;
+MSG_ALSO_COPY_SOURCE
+
+; Also copy source's...
+;
+MSG_USE_OPUS_SETTINGS
+
+; Use Opus Settings
+;
+MSG_COPY_DATESTAMP
+
+; Datestamp
+;
+MSG_COPY_PROTECTION
+
+; Protection bits
+;
+MSG_COPY_COMMENT
+
+; Comment
+;
+MSG_COPY_SET_ARCHIVE
+
+; Set Source Archive bit
+;
+MSG_COPY_URL_COMMENT
+
+; Set Comment to URL
+;
+MSG_COPY_RESCAN
+
+; Rescan Destination
+;
+MSG_COPY_SPACE
+
+; Special Recursive Copy
+;
+MSG_ENV_MENU_PROJECT
+
+; Project
+;
+MSG_ENV_MENU_OPEN
+
+; Open...
+;
+MSG_ENV_MENU_IMPORT
+
+; Import...
+;
+MSG_ENV_MENU_IMPORT_AMFTP
+
+; Import AMFTP Sites...
+;
+MSG_ENV_MENU_SAVE
+
+; Save
+;
+MSG_ENV_MENU_SAVEAS
+
+; SaveAs...
+;
+MSG_ENV_MENU_EXPORT
+
+; Export ASCII...
+;
+MSG_ENV_MENU_QUIT
+
+; Quit
+;
+MSG_ENV_MENU_EDIT
+
+; Edit
+;
+MSG_ENV_MENU_RESET_DEFAULTS
+
+; Reset to Defaults
+;
+MSG_ENV_MENU_LAST_SAVED
+
+; Last Saved
+;
+MSG_ENV_MENU_RESTORE
+
+; Restore
+;
+MSG_ENV_SAVE_OPTIONS
+
+; Save Custom FTP Options
+;
+MSG_ENV_READ_OPTIONS
+
+; Open Custom FTP Options
+;
+MSG_ENV_SAVE_DEFAULT_OPTIONS
+
+; Save DEFAULT FTP Options
+;
+MSG_ENV_READ_DEFAULT_OPTIONS
+
+; Open DEFAULT FTP Options
+;
+MSG_FTP_EXPORT_SITES
+
+; Export Sites
+;
+MSG_FTP_SAVE_SITES
+
+; Save FTP Addressbook
+;
+MSG_FTP_READ_SITES
+
+; Open FTP Addressbook
+;
+MSG_FTP_IMPORT_SITES
+
+; Import FTP Sites
+;
+MSG_ERROR_SAVING
+
+; Error Saving File!
+;
+MSG_RETRY
+
+; _Retry
+;
+MSG_ERROR_LOADING
+
+; Error Reading File!
+;
+MSG_FTP_OPTIONS
+
+; Display FTP Options
+;
+MSG_FTP_EDIT_TITLE
+
+; Edit an FTP Site
+;
+MSG_FTP_NEW_TITLE
+
+; New FTP Site
+;
+MSG_FTP_DEFAULT_OPTIONS_TITLE
+
+; Edit Default FTP Options
+;
+MSG_FTP_CUSTOM_OPTIONS_TITLE
+
+; Edit Custom FTP Options
+;
+MSG_FTP_CONNECT_TITLE
+
+; Connect to FTP Site
+;
+MSG_FTP_ADD_TITLE
+
+; Add FTP Site to Addresbook
+;
+MSG_SELECT_TOOLBAR
+
+; Select Custom FTP Toolbar
+;
+MSG_FTP_ADDR_NAME
+
+; Sites
+;
+MSG_ANON_PASS
+
+; Anon
+;
+MSG_ADR_DC
+
+; Double Click
+;
+MSG_AUTO_CLOSE	
+
+; Auto Close
+;
+MSG_ADR_CONNECT
+
+; Connect
+;
+MSG_ADR_EDIT
+
+; Edit
+;
+; tests
+MSG_SET_PROTECT_OLD
+
+; Current
+;
+MSG_SET_PROTECT_SET
+
+; Set
+;
+MSG_SET_PROTECT_CLEAR
+
+; Clear
+;
+MSG_OK_BUTTON
+
+; _OK
+;
+MSG_ALL_BUTTON
+
+; A_ll
+;
+MSG_SKIP_BUTTON
+
+; S_kip
+;
+MSG_ABORT_BUTTON
+
+; A_bort
+;
+MSG_SELECT_PROTECTION_BITS
+
+; Select protection bits
+;
+MSG_BADADRBOOK
+
+; Error Reading Addressbook
+;
+MSG_FTP_FOUND_FILE
+
+; Found the file
+;
+MSG_FTP_IN_THE_DIR
+
+; in the directory
+;
+MSG_FTP_SHALL_I_GO
+
+; Shall I go there?
+;
+MSG_FTP_NEW_LISTER
+
+; New Lister
+;
+MSG_FTP_ENTER_PATTERN
+
+; Enter file pattern to search for.
+;
+MSG_FTP_SEARCH_COMMENTS
+
+; Search file comments
+;
+MSG_FTP_RECONNECTING
+
+; Reconnecting...
+;
+MSG_FTP_IMPORT_AMFTP_SITES
+
+; Import AMFTP Sites
+;
+MSG_FTP_IMPORT_BAD_AMFTPFILE
+
+; Not an .AmFTPProfiles file!\n Continue anyway?
+;
+MSG_FTP_LAST_SITE
+
+; _Last Site
+;
+MSG_TRANSFER_DISPLAY_BYTES
+
+; Bytes:
+;
+MSG_TRANSFER_DISPLAY_TIMES
+
+; Times:
+;
+MSG_ABORT_COMMENT_START
+
+; Transfer aborted (
+;
+MSG_ABORT_COMMENT_UNKNOWN_SIZE
+
+; unknown
+;
+MSG_ABORT_COMMENT_END
+
+;  total length)
+;
+;
+;	Site-site error default for lst_server_err
+;
+MSG_FTP_SERVER_ERROR
+
+; Command Failed or Server Error
+;

--- a/catalogs/français/icon.ct
+++ b/catalogs/français/icon.ct
@@ -1,0 +1,242 @@
+## version $VER: Icon.catalog 5.61 (08.07.1997)
+## codeset 0
+## language français
+; ************************************************* 
+; Catalog description file for icon.module
+; ************************************************* 
+;
+;
+MSG_ICON_TITLE
+Icône : %s (%s)
+; %s : %s (%s)
+;
+MSG_ICON_SAVE
+_Sauver
+; _Save
+;
+MSG_ICON_NEXT
+S_uivant\x00
+; Ne_xt
+;
+MSG_ICON_CANCEL
+_Annuler\x00
+; _Cancel
+;
+MSG_BLOCKS
+Blocs :
+; Blocks:
+;
+MSG_BYTES
+Octets :\x00
+; Bytes:
+;
+MSG_STACK
+_Pile :
+; St_ack:
+;
+MSG_LAST_CHANGED
+Dernier changement :\x00
+; Last Changed:
+;
+MSG_COMMENT
+_Commentaire :
+; Co_mment:
+;
+MSG_TOOLTYPES
+_Options d'outil :
+; _Tool Types:
+;
+MSG_NEW
+_Nouveau\x00
+; _New
+;
+MSG_DELETE
+_Effacer\x00
+; _Delete
+;
+MSG_DEFAULT_TOOL
+Outil par défaut :
+; Defau_lt Tool:
+;
+MSG_SIZE
+Taille :\x00
+; Size:
+;
+MSG_USED
+Util. :
+; Used:
+;
+MSG_FREE
+Libre :
+; Free:
+;
+MSG_FILE_SYSTEM
+F.Sys :
+; F.Sys:
+;
+MSG_CREATED
+Créé le :
+; Created:
+;
+MSG_VOLUME_IS
+Le volume est en\x00
+; Volume is
+;
+MSG_ICON_DISK
+
+; Volume
+;
+MSG_ICON_DRAWER
+Répertoire
+; Drawer
+;
+MSG_ICON_TOOL
+Outil
+; Tool
+;
+MSG_ICON_PROJECT
+Projet
+; Project
+;
+MSG_ICON_SCRIPT
+
+; Script
+;
+MSG_ICON_ARCHIVED
+Archive
+; Archived
+;
+MSG_ICON_READABLE
+Lecture
+; Readable
+;
+MSG_ICON_WRITABLE
+Ecriture\x00
+; Writable
+;
+MSG_ICON_EXECUTABLE
+Exécution
+; Executable
+;
+MSG_ICON_DELETABLE
+Effacement
+; Deletable
+;
+MSG_VALIDATING
+validation
+; Validating
+;
+MSG_WRITE_PROTECTED
+lecture seule
+; Read Only
+;
+MSG_READ_WRITE
+lecture/ecriture\x00
+; Read/Write
+;
+MSG_UNREADABLE
+illisibilité\x00
+; Unreadable
+;
+MSG_OFS
+
+; OFS
+;
+MSG_FFS
+
+; FFS
+;
+MSG_IOFS
+
+; OFS (I)
+;
+MSG_IFFS
+
+; FFS (I)
+;
+MSG_COFS
+OFS (I)
+; OFS (C)
+;
+MSG_CFFS
+
+; FFS (C)
+;
+MSG_NDOS
+Non DOS
+; Non-DOS
+;
+MSG_MSDOS
+
+; MS-DOS
+;
+MSG_UNKNOWN
+
+; ???
+;
+;
+MSG_ICONINFO_DESC
+Montre/Edite les infos icône\x00
+; Show/edit icon information
+;
+;
+;
+MSG_UNKNOWN_1047
+Spécial
+; 
+;
+MSG_UNKNOWN_1050
+ Auteur : %s\x00
+; 
+;
+MSG_UNKNOWN_1051
+Enlever l'image NewIcons\x00
+; 
+;
+MSG_UNKNOWN_1053
+Okay\x00
+; 
+;
+MSG_UNKNOWN_1054
+Cela enlèvera l'image NewIcon de manière\npermanente de cet icône. Etes vous sûr ?
+; 
+;
+MSG_UNKNOWN_1055
+Okay|Annuler\x00
+; 
+;
+MSG_UNKNOWN_1056
+Endroit :
+; 
+;
+MSG_UNKNOWN_1057
+Poubelle\x00
+; 
+;
+MSG_UNKNOWN_1058
+Périphérique\x00
+; 
+;
+MSG_UNKNOWN_1060
+Enlever l'image originale
+; 
+;
+MSG_UNKNOWN_1061
+Montrer l'image NewIcons\x00
+; 
+;
+MSG_UNKNOWN_1062
+Montrer l'image originale
+; 
+;
+MSG_UNKNOWN_1063
+Cela enlèvera l'image originale de manière\npermanente de cet icône. Etes vous sûr ?
+; 
+;
+MSG_UNKNOWN_1064
+Bord d'icône\x00
+; 
+;
+MSG_UNKNOWN_1065
+Label d'icône
+; 

--- a/catalogs/français/join.ct
+++ b/catalogs/français/join.ct
@@ -1,0 +1,206 @@
+## version $VER: Join.catalog 5.61 (08.07.1997)
+## codeset 0
+## language français
+; ************************************************* 
+; Catalog description file for join.module
+; ************************************************* 
+;
+;
+MSG_JOIN_DESC
+Join des fichiers
+; Join files together
+;
+MSG_SPLIT_DESC
+Découpe un fichier en parts
+; Split a file into parts
+;
+MSG_JOIN_LISTER
+_Joindre...
+; Join _files...
+;
+MSG_JOIN_ADD
+_Ajouter\x00
+; _Add
+;
+MSG_JOIN_REMOVE
+_Enlever\x00
+; _Remove
+;
+MSG_JOIN_CLEAR
+_Vider
+; C_lear
+;
+MSG_JOIN_MOVE_UP
+_Haut
+; _Up
+;
+MSG_JOIN_MOVE_DOWN
+_Bas\x00
+; _Down
+;
+MSG_JOIN_JOIN
+_Joindre\x00
+; _Join
+;
+MSG_JOIN_CANCEL
+_Annuler\x00
+; _Cancel
+;
+MSG_JOIN_TITLE
+Joindre
+; Join
+;
+MSG_JOIN_TO
+_Vers :
+; _To:
+;
+MSG_JOIN_SELECT_FILE
+Choisir fichier
+; Select File
+;
+MSG_REPLACE_RENAME_ABORT
+Remplacer|Renommer|Annuler
+; Replace|Rename|Abort
+;
+MSG_FILE_EXISTS
+Fichier « %s » déjà existant !
+; File '%s' already exists!
+;
+MSG_ENTER_FILENAME
+Entrez le nom de destination.
+; Enter destination filename.
+;
+MSG_OK
+Okay\x00
+; Ok
+;
+MSG_CANCEL
+Annuler
+; Cancel
+;
+MSG_JOINING_FILES
+Jointure de fichiers...
+; Joining files...
+;
+MSG_JOIN_ERROR_OPENING_OUTPUT
+Impossible d'ouvrir « %s » en sortie !
+; Unable to open '%s' for output!
+;
+MSG_JOIN_ERROR
+%s\nErreur %ld %s\x00
+; %s\nError %ld %s
+;
+MSG_JOIN_RETRY
+Réessayer
+; Retry
+;
+MSG_REMOVE
+Supprimer
+; Remove
+;
+MSG_JOIN_ERROR_OPENING_INPUT
+Impossible d'ouvrir « %s » !\x00
+; Unable to open '%s'!
+;
+MSG_JOIN_ERROR_READING
+Erreur en lisant « %s » !
+; Error reading from '%s'!
+;
+MSG_SPLIT_FROM
+_Fichier\x00
+; Split _file
+;
+MSG_SPLIT_STEM
+_Racine
+; _With stem
+;
+MSG_SPLIT_INTO
+Taille _bloc\x00
+; _Chunk size
+;
+MSG_SPLIT_SPLIT
+_Découper
+; _Split
+;
+MSG_SPLIT_SKIP
+_Passer
+; S_kip
+;
+MSG_SPLIT_TO
+_Vers
+; _To
+;
+MSG_SPLIT_TITLE
+Découpage
+; Split
+;
+MSG_SPLIT_ERROR_OPENING_FILE
+Impossible d'ouvrir « %s » !\x00
+; Unable to open '%s'!
+;
+MSG_SPLIT_NO_MEMORY
+Pas assez de mémoire !
+; No memory!
+;
+MSG_SPLITTING_FILE
+Découpage de fichier...
+; Splitting file...
+;
+MSG_ENTER_DISK
+Insérez la disquette suivante dans %s
+; Insert next floppy into %s
+;
+;
+;
+MSG_CHUNK_CUSTOM
+
+; Custom Size
+;
+MSG_CHUNK_FLOPPY_FFS
+
+; 865K (DD Floppy - FFS)
+;
+MSG_CHUNK_HD_FLOPPY_FFS
+
+; 1733K (HD Floppy - FFS)
+;
+MSG_CHUNK_FLOPPY_OFS
+
+; 824K (DD Floppy - OFS)
+;
+MSG_CHUNK_HD_FLOPPY_OFS
+
+; 1651K (HD Floppy - OFS)
+;
+MSG_CHUNK_MSDOS
+
+; 713K (DD MS-DOS)
+;
+MSG_CHUNK_MSDOS_HD
+
+; 1423K (HD MS-DOS)
+;
+MSG_CHUNK_LAST
+
+; -
+;
+;
+MSG_UNKNOWN_2000
+Taille spéciale
+; 
+;
+MSG_UNKNOWN_2001
+865Ko (Disquette DD)\x00
+; 
+;
+MSG_UNKNOWN_2002
+1733Ko (Disquette HD)
+; 
+;
+MSG_UNKNOWN_2003
+713Ko (MS-DOS DD)
+; 
+;
+MSG_UNKNOWN_2004
+1423Ko (MS-DOS HD)
+; 

--- a/catalogs/français/listerformat.ct
+++ b/catalogs/français/listerformat.ct
@@ -1,0 +1,127 @@
+## version $VER: ListerFormat.catalog 5.61 (08.07.1997)
+## codeset 0
+## language français
+; ************************************************* 
+; Catalog description file for listerformat.module
+; ************************************************* 
+;
+;
+MSG_LISTER_FORMAT_TITLE
+Format de listeur
+; List Format
+;
+MSG_LISTER_AVAILABLE_DISPLAY_ITEMS
+Disponibles...
+; Available...
+;
+MSG_LISTER_SELECTED_DISPLAY_ITEMS
+Afficher/Trier...
+; Display/Sort...
+;
+MSG_LISTER_LIST_FILENAME
+Nom
+; File Name
+;
+MSG_LISTER_LIST_FILESIZE
+Taille
+; File Size
+;
+MSG_LISTER_LIST_PROTECTION
+
+; Protection
+;
+MSG_LISTER_LIST_DATE
+Date\x00
+; File Date
+;
+MSG_LISTER_LIST_COMMENT
+Commentaire
+; Comment
+;
+MSG_LISTER_LIST_FILETYPE
+Type\x00
+; File Type
+;
+MSG_LISTER_LIST_OWNER
+Propriétaire\x00
+; Owner
+;
+MSG_LISTER_LIST_GROUP
+Groupe
+; Group
+;
+MSG_LISTER_LIST_NETPROTECTION
+Accès réseau\x00
+; Net Access
+;
+MSG_LISTER_ENTRY_SEPARATION
+_Séparation
+; _Entry Separation
+;
+MSG_LISTER_REVERSE_SORTING
+_Tri inverse\x00
+; _Reverse Sorting
+;
+MSG_LISTER_SEPARATION_MIX
+Mixer Fich./Rép.\x00
+; Mix Files/Dirs
+;
+MSG_LISTER_SEPARATION_DIRS
+Répertoires
+; Directories First
+;
+MSG_LISTER_SEPARATION_FILES
+Fichiers\x00
+; Files First
+;
+MSG_LISTER_SHOW
+Filtre : _Montrer
+; _Show Filter
+;
+MSG_LISTER_HIDE
+Filtre : Cac_her\x00
+; _Hide Filter
+;
+MSG_LISTER_REJECT_ICONS
+_Filtrer icônes
+; _Filter Icons
+;
+MSG_LISTER_HIDDEN_BIT
+_Cachés
+; H_idden
+;
+MSG_LISTER_USE
+_Utiliser
+; _Use
+;
+MSG_LISTER_CANCEL
+_Annuler\x00
+; _Cancel
+;
+MSG_LISTER_LIST_VERSION
+
+; Version
+;
+MSG_LISTER_SAVE
+_Sauver
+; S_ave
+;
+MSG_DEFAULTS
+_Valeurs par défaut
+; Reset to _Defaults
+;
+MSG_FTP_DEFAULTS
+_Jauge occupation
+; Reset FTP Defaults
+;
+MSG_LISTER_FUEL_GAUGE
+_Hériter\x00
+; Free Space _Gauge
+;
+MSG_LISTER_INHERIT
+
+; I_nherit
+;
+MSG_SET_AS_DEFAULTS
+
+; Set _As Defaults

--- a/catalogs/français/misc.ct
+++ b/catalogs/français/misc.ct
@@ -1,0 +1,20 @@
+## version $VER: Misc.catalog 5.61 (08.07.1997)
+## codeset 0
+## language français
+; ************************************************* 
+; Catalog description file for misc.module
+; ************************************************* 
+;
+;
+MSG_BEEP_DESC
+Fait un bip
+; Makes a beep sound
+;
+MSG_FLASH_DESC
+Flashe l'écran
+; Flashes the display
+;
+MSG_ALARM_DESC
+Sonne une alarme\x00
+; Sounds an alarm
+;

--- a/catalogs/français/pathformat.ct
+++ b/catalogs/français/pathformat.ct
@@ -1,0 +1,60 @@
+## version $VER: PathFormat.catalog 5.61 (08.07.1997)
+## codeset 0
+## language français
+; ************************************************* 
+; Catalog description file for pathformat.module
+; ************************************************* 
+;
+;
+MSG_PATHFORMAT_TITLE
+Editer chemins
+; Edit Paths
+;
+MSG_PATHFORMAT_SAVE
+_Sauver
+; _Save
+;
+MSG_PATHFORMAT_CANCEL
+_Annuler\x00
+; _Cancel
+;
+MSG_PATHFORMAT_KEY
+_Raccourci
+; _Key
+;
+MSG_PATHFORMAT_ADD
+_Ajouter\x00
+; _Add
+;
+MSG_PATHFORMAT_REMOVE
+E_ffacer\x00
+; _Remove
+;
+MSG_PATHFORMAT_EDIT
+_Editer
+; _Edit
+;
+MSG_PATHFORMAT_PATH
+_Chemin
+; _Path
+;
+MSG_PATHFORMAT_NEW_LISTER
+_Nouveau listeur\x00
+; _New lister mode
+;
+MSG_MODE_NONE
+Aucun
+; None
+;
+MSG_MODE_NAME
+Nom
+; Name
+;
+MSG_MODE_ICON
+Icône
+; Icon
+;
+MSG_MODE_ICON_ACTION
+Icône action\x00
+; Icon Action
+;

--- a/catalogs/français/play.ct
+++ b/catalogs/français/play.ct
@@ -1,0 +1,73 @@
+## version $VER: Play.catalog 5.61 (08.07.1997)
+## codeset 0
+## language français
+; ************************************************* 
+; Catalog description file for play.module
+; ************************************************* 
+;
+;
+MSG_NEXT
+_Suivant\x00
+; _Next
+;
+MSG_ABORT
+_Annuler\x00
+; _Abort
+;
+MSG_PLAY_TITLE
+
+; Play
+;
+MSG_FILENAME
+Fichier :
+; File:
+;
+MSG_LENGTH
+Taille :\x00
+; Length:
+;
+MSG_TYPE
+Type :
+; Type:
+;
+MSG_TYPE_STEREO
+Stéréo
+; Stereo
+;
+MSG_TYPE_MONO
+
+; Mono
+;
+MSG_TYPE_RAW
+Brut\x00
+; Raw
+;
+MSG_STATUS
+Statut :\x00
+; Status:
+;
+MSG_STATUS_LOADING
+Lecture du fichier...
+; Reading file...
+;
+MSG_STATUS_DECOMPRESSING
+Décompression...\x00
+; Decompressing...
+;
+MSG_STATUS_PLAYING
+Lecture du son...
+; Playing sound...
+;
+;
+MSG_PLAY_DESC
+Joue des sons
+; Play sound files
+;
+MSG_PLAY_NEXT
+Suivant
+; Next
+;
+MSG_PLAY_ABORT
+Annuler
+; Abort
+;

--- a/catalogs/français/print.ct
+++ b/catalogs/français/print.ct
@@ -1,0 +1,189 @@
+## version $VER: Print.catalog 5.61 (08.07.1997)
+## codeset 0
+## language français
+; ************************************************* 
+; Catalog description file for print.module
+; ************************************************* 
+;
+;
+MSG_PRINTREQ_TITLE
+Imprimer\x00
+; Print
+;
+MSG_PRINTING_TITLE
+Impression...
+; Printing...
+;
+MSG_PRINT
+_Imprimer
+; _Print
+;
+MSG_CANCEL
+_Annuler\x00
+; _Cancel
+;
+MSG_TEXT
+Texte
+; Text
+;
+MSG_HEADER_FOOTER
+Entête/Pied de page
+; Header/Footer
+;
+MSG_PRINT_QUALITY
+_Qualité\x00
+; _Quality
+;
+MSG_PRINT_SPACING
+De_nsité\x00
+; _Spacing
+;
+MSG_PRINT_PITCH
+_Largeur\x00
+; P_itch
+;
+MSG_PRINT_LEFT_MARGIN
+Marge _gauche
+; _Left Margin
+;
+MSG_PRINT_RIGHT_MARGIN
+Marge _droite
+; _Right Margin
+;
+MSG_PRINT_PAGE_LENGTH
+Ta_ille de page
+; P_age Length
+;
+MSG_PRINT_TAB_SIZE
+Ta_bulation
+; _Tab Size
+;
+MSG_PRINT_QUALITY_DRAFT
+Brouillon
+; Draft
+;
+MSG_PRINT_QUALITY_LETTER
+Lettre
+; Letter
+;
+MSG_PRINT_SPACING_6
+6 LPP
+; 6 LPI
+;
+MSG_PRINT_SPACING_8
+8 LPP
+; 8 LPI
+;
+MSG_PRINT_PITCH_PICA
+
+; Pica
+;
+MSG_PRINT_PITCH_ELITE
+
+; Elite
+;
+MSG_PRINT_PITCH_FINE
+Fin
+; Fine
+;
+MSG_PRINT_CONFIGURATION
+_Configuration...
+; c_onfiguration...
+;
+MSG_PRINT_HEADER
+Entête
+; Header
+;
+MSG_PRINT_FOOTER
+Pied\x00
+; Footer
+;
+MSG_PRINT_TITLE
+_Titre
+; Titl_e
+;
+MSG_PRINT_DATE
+
+; _Date
+;
+MSG_PRINT_PAGE
+N_uméro de page
+; Pa_ge
+;
+MSG_PRINT_STYLE
+
+; St_yle
+;
+MSG_PRINT_STYLE_NORMAL
+
+; Normal
+;
+MSG_PRINT_STYLE_BOLD
+Gras\x00
+; Bold
+;
+MSG_PRINT_STYLE_ITALICS
+Italique\x00
+; Italics
+;
+MSG_PRINT_STYLE_UNDERLINE
+Souligné\x00
+; Uline
+;
+MSG_ABORT
+Annuler
+; Abort
+;
+MSG_OK
+Okay\x00
+; OK
+;
+MSG_OPENING_PRINTER
+Ouverture de l'imprimante...\x00
+; Opening printer...
+;
+MSG_CANT_OPEN_PRINTER
+Impossible d'ouvrir l'imprimante !
+; Couldn't open printer!
+;
+MSG_PRINTER_ERROR
+Erreur (%ld) en imprimant.
+; An error occurred (%ld) while printing.
+;
+MSG_REALLY_ABORT
+Vraiment annuler l'impression ?
+; Really abort print?
+;
+MSG_RETRY_CANCEL
+Réessayer|Annuler
+; Retry|Cancel
+;
+MSG_ABORT_RESUME
+Annuler|Continuer
+; Abort|Continue
+;
+MSG_PRINT_PAGENUM
+Page\x00
+; Page 
+;
+;
+MSG_PRINT_DESC
+Imprime les fichiers\x00
+; Print text files
+;
+MSG_PRINT_OUTPUT
+S_ortie
+; Outp_ut
+;
+MSG_PRINT_OUTPUT_PRINTER
+Imprimante
+; Printer
+;
+MSG_PRINT_OUTPUT_FILE
+Fichier
+; File
+;
+MSG_SELECT_OUTPUT_FILE
+Choisir fichier de sortie
+; Select Output File
+;

--- a/catalogs/français/read.ct
+++ b/catalogs/français/read.ct
@@ -1,0 +1,171 @@
+## version $VER: Read.catalog 5.61 (08.07.1997)
+## codeset 0
+## language français
+; ************************************************* 
+; Catalog description file for read.module
+; ************************************************* 
+;
+;
+MSG_READING_FILE
+Lecture du fichier « %s »...\x00
+; Reading file '%s'...
+;
+MSG_CANT_OPEN_FILE
+Impossible d'ouvrir « %s » !\x00
+; Unable to open file '%s'!
+;
+MSG_FILE_TITLE
+%s  %s  %ld lignes, %ld octets   Mode : %s, Tab : %ld
+; %s  %s  %ld lines, %ld bytes   mode=%s, tab=%ld
+;
+MSG_MENU_FILE
+Fichier
+; File
+;
+MSG_MENU_NEXT
+Suivant
+; Next
+;
+MSG_MENU_SEARCH
+Chercher...
+; Search...
+;
+MSG_MENU_REPEAT
+Chercher suivant\x00
+; Repeat Search  
+;
+MSG_MENU_PRINT
+Imprimer...
+; Print...
+;
+MSG_MENU_QUIT
+Quitter
+; Quit
+;
+MSG_MENU_SETTINGS
+Réglages\x00
+; Settings
+;
+MSG_MENU_TAB
+Tabulations
+; Tab Size
+;
+MSG_MENU_SAVE
+Sauver
+; Save Settings
+;
+MSG_ENTER_SEARCH_STRING
+Entrez la chaîne à chercher
+; Enter text to search for.
+;
+MSG_SEARCH_NO_CASE
+_Ignorer min/MAJ\x00
+; _Ignore Case
+;
+MSG_SEARCH_WILD
+_Motifs
+; _Wildcards
+;
+MSG_SEARCH_ONLYWORD
+Mo_ts entiers
+; _Only Words
+;
+MSG_SEARCH_REVERSE
+_En arrière
+; _Reverse Search
+;
+MSG_OK_BUTTON
+Okay\x00
+; OK
+;
+MSG_CANCEL_BUTTON
+Annuler
+; Cancel
+;
+MSG_STRING_NOT_FOUND
+Chaîne introuvable.
+; String not found.
+;
+;
+MSG_READ_DESCRIPTION
+Lit les fichiers texte
+; Read text files
+;
+;
+MSG_MENU_MODE
+
+; Mode
+;
+MSG_MENU_MODE_NORMAL
+
+; Normal
+;
+MSG_MENU_MODE_ANSI
+
+; ANSI
+;
+MSG_MENU_MODE_HEX
+
+; Hex
+;
+;
+MSG_MENU_USE_SCREEN
+Utiliser un écran
+; Use Screen
+;
+MSG_MENU_SCREEN_MODE
+Choisir le mode écran...\x00
+; Pick Screen Mode...
+;
+MSG_MENU_SELECT_FONT
+Choisir la police...\x00
+; Pick Font...
+;
+MSG_SCREEN_TITLE
+Afficheur de textes - Directory Opus\x00
+; Directory Opus Text Viewer
+;
+MSG_MENU_SAVE_AS
+Sauver en...\x00
+; Save As...
+;
+MSG_ENTER_FILENAME
+Entrez le nom du fichier\x00
+; Enter Filename
+;
+MSG_IO_ERROR
+Erreur I/O
+; IO Error
+;
+MSG_ERROR_CODE
+Erreur DOS %ld
+; DOS error %ld
+;
+MSG_MENU_TO_EDITOR
+Vers l'éditeur...
+; To Editor...
+;
+MSG_MENU_SELECT_EDITOR
+Choisir l'éditeur
+; Pick Editor...
+;
+MSG_OK_CANCEL_BUTTON
+Okay|Annuler\x00
+; OK|Cancel
+;
+MSG_SELECT_EDITOR
+Entrez la fonction d'appel de l'éditeur
+; Enter function to call text editor
+;
+MSG_READING_FILE_TITLE
+Lecture du fichier...
+; Reading file...
+;
+MSG_COUNTING_LINES
+Comptage des lignes...
+; Counting lines...
+;
+MSG_CLOSE
+
+; Close
+;

--- a/catalogs/français/show.ct
+++ b/catalogs/français/show.ct
@@ -1,0 +1,141 @@
+## version $VER: Show.catalog 5.61 (08.07.1997)
+## codeset 0
+## language français
+; ************************************************* 
+; Catalog description file for show.module
+; ************************************************* 
+;
+;
+MSG_OK
+_Okay
+; _OK
+;
+MSG_INFO_TITLE
+Informations sur l'image\x00
+; Picture Information
+;
+MSG_INFO_FILE
+Fichier :
+; File:
+;
+MSG_INFO_IMAGE_SIZE
+Taille :\x00
+; Image Size:
+;
+MSG_INFO_COLOURS
+Couleurs :
+; Colours:
+;
+MSG_INFO_MODE
+Mode écran :\x00
+; Display Mode:
+;
+MSG_INFO_FRAME
+Trame :
+; Frame:
+;
+MSG_INFO_ANIM
+Type d'animation :
+; Anim Type:
+;
+MSG_INFO_FRAME_NUM
+%ld sur %ld @ %ld/sec
+; %ld of %ld @ %ld/sec
+;
+MSG_PRINT_ASPECT
+_Aspect :
+; _Aspect:
+;
+MSG_PRINT_IMAGE
+_Image :\x00
+; _Image:
+;
+MSG_PRINT_SHADE
+_Ombre :\x00
+; _Shade:
+;
+MSG_PRINT_PLACEMENT
+Po_sition :
+; P_lacement:
+;
+MSG_PRINT_FORM_FEED
+_Saut de page
+; _Form Feed
+;
+MSG_PRINT_PRINT_TITLE
+Imprimer _titre
+; Print _Title
+;
+MSG_PRINT
+_Imprimer
+; _Print
+;
+MSG_PRINT_ASPECT_PORTRAIT
+
+; Portrait
+;
+MSG_PRINT_ASPECT_LANDSCAPE
+Paysage
+; Landscape
+;
+MSG_PRINT_IMAGE_POSITIVE
+
+; Positive
+;
+MSG_PRINT_IMAGE_NEGATIVE
+Négative\x00
+; Negative
+;
+MSG_PRINT_SHADE_BW
+Noir et blanc
+; Black & White
+;
+MSG_PRINT_SHADE_GREY
+Niv. de gris\x00
+; Gray Scale
+;
+MSG_PRINT_SHADE_COLOUR
+Couleur
+; Colour
+;
+MSG_PRINT_PLACEMENT_CENTER
+Centrée
+; Centre
+;
+MSG_PRINT_PLACEMENT_LEFT
+A gauche\x00
+; Left
+;
+MSG_OPENING_PRINTER
+Ouverture de l'imprimante...\x00
+; Opening printer...
+;
+MSG_INITIALISING_PRINTER
+Initialisation de l'imprimante...
+; Initialising printer...
+;
+MSG_PRINTING_PICTURE
+Impression de l'image...\x00
+; Printing picture...
+;
+MSG_ABORTING_PRINT
+Annulation...
+; Aborting...
+;
+MSG_ANIM_TITLE
+Animation : %s\tTrame %ld sur %ld\t%ld x %ld x %ld\n\n
+; Animation : %s\tFrame %ld of %ld\t%ld x %ld x %ld\n\n
+;
+MSG_ILBM_TITLE
+Image : %s\t%ld x %ld x %ld\n\n\x00
+; Picture : %s\t%ld x %ld x %ld\n\n
+;
+MSG_INFO_TYPE
+Type d'image :
+; Picture Type:
+;
+;
+MSG_SHOW_DESC
+Affiche les images
+; Show pictures
+;

--- a/documents/dopus5/ModuleCallbacks.md
+++ b/documents/dopus5/ModuleCallbacks.md
@@ -1,0 +1,335 @@
+# Directory Opus 5 Module Callback System
+
+This document describes the external command callback system used by modules to communicate with Directory Opus 5.
+
+## Overview
+
+Modules interact with Directory Opus 5 via a callback hook, `function_external_hook`. This hook is passed to the module's entry point and can be called by the module with various `EXTCMD_*` codes and associated data packets.
+
+The implementation is primarily located in:
+- `source/Include/libraries/module.h`: Definitions of `EXTCMD_*` codes and packet structures.
+- `source/Program/function_internal.c`: The main callback dispatcher (`function_external_hook`).
+- `source/Program/callback_lister.c`: Most implementations of the actual hook functions.
+- `source/Program/callback_help.c`: Implementation for help-related callbacks.
+
+---
+
+## Callback Command Reference
+
+### `EXTCMD_GET_SOURCE` (0)
+- **Description**: Gets the current source path.
+- **Handler**: `HookGetSource` (`source/Program/callback_lister.c`)
+- **Packet**: `char *pathbuf` (Pointer to a buffer of at least 256 characters)
+- **Return Value**: `PathNode *` (Pointer to the current source PathNode, or 0 if none)
+- **Synchronous**: Yes
+
+### `EXTCMD_NEXT_SOURCE` (1)
+- **Description**: Advances to the next source path and retrieves it.
+- **Handler**: `HookNextSource` (`source/Program/callback_lister.c`)
+- **Packet**: `char *pathbuf` (Pointer to a buffer of at least 256 characters)
+- **Return Value**: `PathNode *` (Pointer to the next source PathNode, or 0 if none)
+- **Synchronous**: Yes
+
+### `EXTCMD_UNLOCK_SOURCE` (2)
+- **Description**: Unlocks the current source paths.
+- **Handler**: `HookUnlockSource` (`source/Program/callback_lister.c`)
+- **Packet**: None
+- **Return Value**: None
+- **Synchronous**: Yes
+
+### `EXTCMD_GET_ENTRY` (3)
+- **Description**: Gets the next entry from the current source.
+- **Handler**: `HookGetEntry` (`source/Program/callback_lister.c`)
+- **Packet**: None
+- **Return Value**: `APTR` (Pointer to a `FunctionEntry` or equivalent, or 0 if no more entries)
+- **Synchronous**: Yes
+
+### `EXTCMD_END_ENTRY` (4)
+- **Description**: Finishes processing a specific entry.
+- **Handler**: `HookEndEntry` (`source/Program/callback_lister.c`)
+- **Packet**: `struct endentry_packet *`
+- **Return Value**: None
+- **Synchronous**: Yes
+
+### `EXTCMD_RELOAD_ENTRY` (5)
+- **Description**: Marks an entry for reloading in its lister.
+- **Handler**: `HookReloadEntry` (`source/Program/callback_lister.c`)
+- **Packet**: `FunctionEntry *entry`
+- **Return Value**: None
+- **Synchronous**: Yes
+
+### `EXTCMD_OPEN_PROGRESS` (6)
+- **Description**: Opens a progress indicator for the current operation.
+- **Handler**: `HookOpenProgress` (`source/Program/callback_lister.c`)
+- **Packet**: `struct progress_packet *`
+- **Return Value**: None
+- **Synchronous**: Yes (Calls `IPC_Command` internally)
+
+### `EXTCMD_UPDATE_PROGRESS` (7)
+- **Description**: Updates an existing progress indicator.
+- **Handler**: `HookUpdateProgress` (`source/Program/callback_lister.c`)
+- **Packet**: `struct progress_packet *`
+- **Return Value**: None
+- **Synchronous**: Yes (Calls `lister_command` internally)
+
+### `EXTCMD_CLOSE_PROGRESS` (8)
+- **Description**: Closes the progress indicator.
+- **Handler**: `HookCloseProgress` (`source/Program/callback_lister.c`)
+- **Packet**: `struct progress_packet *` (Uses the `path` member)
+- **Return Value**: None
+- **Synchronous**: Yes (Calls `lister_command` internally)
+
+### `EXTCMD_CHECK_ABORT` (9)
+- **Description**: Checks if the user has requested to abort the current operation.
+- **Handler**: `HookCheckAbort` (`source/Program/callback_lister.c`)
+- **Packet**: None
+- **Return Value**: `BOOL` (True if aborted, False otherwise)
+- **Synchronous**: Yes
+
+### `EXTCMD_ENTRY_COUNT` (10)
+- **Description**: Returns the total number of entries to be processed.
+- **Handler**: `HookEntryCount` (`source/Program/callback_lister.c`)
+- **Packet**: None
+- **Return Value**: `long` (Number of entries)
+- **Synchronous**: Yes
+
+### `EXTCMD_GET_WINDOW` (11)
+- **Description**: Gets the window handle associated with a PathNode.
+- **Handler**: `HookGetWindow` (`source/Program/callback_lister.c`)
+- **Packet**: `PathNode *path`
+- **Return Value**: `struct Window *`
+- **Synchronous**: Yes
+
+### `EXTCMD_GET_DEST` (12)
+- **Description**: Gets the current destination path.
+- **Handler**: `HookGetDest` (`source/Program/callback_lister.c`)
+- **Packet**: `char *pathbuf`
+- **Return Value**: `PathNode *`
+- **Synchronous**: Yes
+
+### `EXTCMD_END_SOURCE` (13)
+- **Description**: Finishes with the current source path.
+- **Handler**: `HookEndSource` (`source/Program/callback_lister.c`)
+- **Packet**: `long complete` (Status flag)
+- **Return Value**: None
+- **Synchronous**: Yes
+
+### `EXTCMD_END_DEST` (14)
+- **Description**: Finishes with the current destination path.
+- **Handler**: `HookEndDest` (`source/Program/callback_lister.c`)
+- **Packet**: `long complete` (Status flag)
+- **Return Value**: None
+- **Synchronous**: Yes
+
+### `EXTCMD_ADD_CHANGE` (15)
+- **Description**: (Not implemented in `function_internal.c` handler - possibly deprecated)
+- **Handler**: N/A
+- **Packet**: `struct addchange_packet *`
+- **Return Value**: N/A
+- **Synchronous**: N/A
+
+### `EXTCMD_ADD_FILE` (16)
+- **Description**: Adds a new file entry to a lister.
+- **Handler**: `HookAddFile` (`source/Program/callback_lister.c`)
+- **Packet**: `struct addfile_packet *`
+- **Return Value**: None
+- **Synchronous**: Yes
+
+### `EXTCMD_GET_HELP` (17)
+- **Description**: Shows help for a specific topic or file.
+- **Handler**: `HookShowHelp` (`source/Program/callback_help.c`)
+- **Packet**: `char *topic`
+- **Return Value**: None
+- **Synchronous**: Yes
+
+### `EXTCMD_GET_PORT` (18)
+- **Description**: Gets the name of the DOpus ARexx port.
+- **Handler**: `HookGetPort` (`source/Program/callback_lister.c`)
+- **Packet**: `char *portname` (Buffer to store name)
+- **Return Value**: `struct MsgPort *`
+- **Synchronous**: Yes
+
+### `EXTCMD_GET_SCREEN` (19)
+- **Description**: Gets the name and handle of the DOpus public screen.
+- **Handler**: `HookGetScreen` (`source/Program/callback_lister.c`)
+- **Packet**: `char *screenname` (Buffer to store name)
+- **Return Value**: `struct Screen *`
+- **Synchronous**: Yes
+
+### `EXTCMD_REPLACE_REQ` (20)
+- **Description**: Shows the File Exists / Replace requester.
+- **Handler**: `HookReplaceReq` (`source/Program/callback_lister.c`)
+- **Packet**: `struct replacereq_packet *`
+- **Return Value**: `long` (Result of requester)
+- **Synchronous**: Yes
+
+### `EXTCMD_REMOVE_ENTRY` (21)
+- **Description**: Marks an entry for removal from its list.
+- **Handler**: `HookRemoveEntry` (`source/Program/callback_lister.c`)
+- **Packet**: `FunctionEntry *entry`
+- **Return Value**: None
+- **Synchronous**: Yes
+
+### `EXTCMD_GET_SCREENDATA` (22)
+- **Description**: Retrieves data about the DOpus screen (colors, depth, etc).
+- **Handler**: `HookGetScreenData` (`source/Program/callback_lister.c`)
+- **Packet**: None
+- **Return Value**: `DOpusScreenData *` (Must be freed with `EXTCMD_FREE_SCREENDATA`)
+- **Synchronous**: Yes
+
+### `EXTCMD_FREE_SCREENDATA` (23)
+- **Description**: Frees screen data obtained from `EXTCMD_GET_SCREENDATA`.
+- **Handler**: `HookFreeScreenData` (`source/Program/callback_lister.c`)
+- **Packet**: `DOpusScreenData *data`
+- **Return Value**: None
+- **Synchronous**: Yes
+
+### `EXTCMD_CREATE_FILE_ENTRY` (24)
+- **Description**: (Not implemented in `function_internal.c` handler)
+- **Handler**: N/A
+- **Packet**: N/A
+- **Return Value**: N/A
+- **Synchronous**: N/A
+
+### `EXTCMD_FREE_FILE_ENTRY` (25)
+- **Description**: (Not implemented in `function_internal.c` handler)
+- **Handler**: N/A
+- **Packet**: N/A
+- **Return Value**: N/A
+- **Synchronous**: N/A
+
+### `EXTCMD_SORT_FILELIST` (26)
+- **Description**: (Not implemented in `function_internal.c` handler)
+- **Handler**: N/A
+- **Packet**: `struct sortlist_packet *`
+- **Return Value**: N/A
+- **Synchronous**: N/A
+
+### `EXTCMD_NEW_LISTER` (27)
+- **Description**: (Not implemented in `function_internal.c` handler)
+- **Handler**: N/A
+- **Packet**: N/A
+- **Return Value**: N/A
+- **Synchronous**: N/A
+
+### `EXTCMD_GET_POINTER` (28)
+- **Description**: Retrieves a pointer to a specific internal DOpus structure.
+- **Handler**: `HookGetPointer` (`source/Program/callback_lister.c`)
+- **Packet**: `struct pointer_packet *`
+- **Return Value**: `ULONG` (Pointer value)
+- **Synchronous**: Yes
+
+### `EXTCMD_FREE_POINTER` (29)
+- **Description**: Frees a pointer obtained via `EXTCMD_GET_POINTER`.
+- **Handler**: `HookFreePointer` (`source/Program/callback_lister.c`)
+- **Packet**: `struct pointer_packet *`
+- **Return Value**: None
+- **Synchronous**: Yes
+
+### `EXTCMD_SEND_COMMAND` (30)
+- **Description**: Sends an ARexx command to DOpus.
+- **Handler**: `HookSendCommand` (`source/Program/callback_lister.c`)
+- **Packet**: `struct command_packet *`
+- **Return Value**: `ULONG` (Success flag)
+- **Synchronous**: Yes (Waits for ARexx reply if `COMMANDF_RESULT` is set)
+
+### `EXTCMD_DEL_FILE` (31)
+- **Description**: Deletes a file and updates the lister.
+- **Handler**: `HookDelFile` (`source/Program/callback_lister.c`)
+- **Packet**: `struct delfile_packet *`
+- **Return Value**: None
+- **Synchronous**: Yes
+
+### `EXTCMD_DO_CHANGES` (32)
+- **Description**: Flushes any pending lister changes.
+- **Handler**: `HookDoChanges` (`source/Program/callback_lister.c`)
+- **Packet**: None
+- **Return Value**: None
+- **Synchronous**: Yes
+
+### `EXTCMD_LOAD_FILE` (33)
+- **Description**: Loads a file into a lister or reloads it.
+- **Handler**: `HookLoadFile` (`source/Program/callback_lister.c`)
+- **Packet**: `struct loadfile_packet *`
+- **Return Value**: None
+- **Synchronous**: Yes
+
+---
+
+## Packet Structures
+
+### `progress_packet`
+```c
+struct progress_packet {
+    struct _PathNode *path;
+    char *name;
+    ULONG count;
+};
+```
+
+### `endentry_packet`
+```c
+struct endentry_packet {
+    struct _FunctionEntry *entry;
+    BOOL deselect;
+};
+```
+
+### `addfile_packet`
+```c
+struct addfile_packet {
+    char *path;
+    struct FileInfoBlock *fib;
+    struct ListerWindow *lister;
+};
+```
+
+### `delfile_packet`
+```c
+struct delfile_packet {
+    char *path;
+    char *name;
+    struct ListerWindow *lister;
+};
+```
+
+### `loadfile_packet`
+```c
+struct loadfile_packet {
+    char *path;
+    char *name;
+    short flags;
+    short reload;
+};
+```
+
+### `replacereq_packet`
+```c
+struct replacereq_packet {
+    struct Window *window;
+    struct Screen *screen;
+    IPCData *ipc;
+    struct FileInfoBlock *file1;
+    struct FileInfoBlock *file2;
+    short default_option;
+};
+```
+
+### `pointer_packet`
+```c
+struct pointer_packet {
+    ULONG type;
+    APTR pointer;
+    ULONG flags;
+};
+```
+
+### `command_packet`
+```c
+struct command_packet {
+    char *command;
+    ULONG flags;
+    char *result;
+    ULONG rc;
+};
+```

--- a/documents/dopus5/ModuleDiscovery.md
+++ b/documents/dopus5/ModuleDiscovery.md
@@ -1,0 +1,44 @@
+# Module Discovery and Identification in Directory Opus 5
+
+## Overview
+Directory Opus 5 uses an asynchronous, message-driven system to discover and register modules located in `dopus5:modules/`. This ensures the UI remains responsive while external libraries are scanned and identified.
+
+## Discovery Workflow
+
+### 1. Directory Notification
+The system monitors the `dopus5:modules` directory for changes.
+- **Initialization**: `source/Program/main.c` calls `start_file_notify("dopus5:modules", NOTIFY_MODULES_CHANGED, GUI->appmsg_port)`.
+- **Signal**: When a file is added, removed, or modified, a `NOTIFY_MODULES_CHANGED` message is sent to the main application port.
+
+### 2. Event Handling
+The main event loop in `source/Program/event_loop.c` listens for these notifications.
+- **Reception**: Upon receiving `NOTIFY_MODULES_CHANGED`, the loop launches a background process named `dopus_module_sniffer`.
+- **Command**: The sniffer is started with the `MAIN_SNIFF_MODULES` command and the `SNIFF_BOTH` flag.
+
+### 3. Background Sniffing
+The background process (`source/Program/misc_proc.c`) executes the sniffing logic.
+- **Execution**: It calls `update_commands()`, which in turn calls `init_commands_scan(SCAN_MODULES)`.
+- **Scanning**: `init_commands_scan` uses `MatchFirst`/`MatchNext` to find all `#?.module` files in `dopus5:modules/`.
+
+### 4. Identification (`Module_Identify`)
+For each discovered module:
+- **Library Open**: The module is opened as a standard Amiga shared library.
+- **Module Metadata**: The system calls `Module_Identify(-1)` to retrieve a `ModuleInfo` structure. This contains the module's descriptive name, the number of functions it exports, and capability flags.
+- **Function Metadata**: For each function index (`0` to `function_count - 1`), `Module_Identify(num)` is called to retrieve the descriptive name/string for that specific command.
+
+### 5. Registration
+Once identified, the module's functions are registered as commands.
+- **Add Command**: `add_command()` is called for each function, adding it to `GUI->command_list`.
+- **Internal Mapping**: The command stores the module filename and the function ID for later execution.
+
+## Technical Details
+- **Location**: `dopus5:modules/`
+- **Suffix**: `.module`
+- **Exclusion List**: Defined in `source/Program/commands.c` (e.g., `configopus.module`, `read.module`).
+- **Data Structure**: `GUI->modules_list` tracks currently loaded modules and their datestamps to prevent unnecessary re-scanning.
+
+## Key Files
+- `source/Program/main.c`: Notification initialization.
+- `source/Program/event_loop.c`: Notification event handling.
+- `source/Program/misc_proc.c`: Background process dispatch.
+- `source/Program/commands.c`: Directory scanning, identification, and registration.

--- a/source/Include/dopus/version.h
+++ b/source/Include/dopus/version.h
@@ -16,7 +16,7 @@
 
 // set the program version/revision
 #define PROG_VERSION    5
-#define PROG_REVISION   92
+#define PROG_REVISION   93
 
 // set the library & modules version/revision
 #define LIB_VERSION    73

--- a/source/Include/dopus/version.h
+++ b/source/Include/dopus/version.h
@@ -76,6 +76,6 @@
 #define LIB_STRING STRI(LIB_VERSION)"."STRI(LIB_REVISION)" "STRI(PLATFORM)" ("DOPUSDATE")"
 #define CMD_STRING STRI(CMD_VERSION)"."STRI(CMD_REVISION)" "STRI(PLATFORM)" ("DOPUSDATE")"
 
-#define COPYRIGHT  " Copyright (c) 2012-2015 Dopus5 Open Source Team "
+#define COPYRIGHT  " Copyright (c) 2012-2026 Dopus5 Open Source Team "
 
 #endif /* DOPUS_VERSION_H */

--- a/source/Include/inline/SysInfo.h
+++ b/source/Include/inline/SysInfo.h
@@ -5,6 +5,10 @@
 	#define CLIB_SYSINFO_PROTOS_H
 #endif
 
+#ifndef __INLINE_MACROS_H
+	#include <inline/macros.h>
+#endif
+
 #ifndef EXEC_TYPES_H
 	#include <exec/types.h>
 #endif
@@ -16,137 +20,40 @@
 	#define SYSINFO_BASE_NAME SysInfoBase
 #endif
 
-#define InitSysInfo()                                                                         \
-	({                                                                                        \
-		register char *_InitSysInfo__bn __asm("a6") = (char *)(SYSINFO_BASE_NAME);            \
-		((struct SysInfo * (*)(char *__asm("a6")))(_InitSysInfo__bn - 30))(_InitSysInfo__bn); \
-	})
+#define InitSysInfo() \
+	LP0(0x1e, struct SysInfo *, InitSysInfo, , SYSINFO_BASE_NAME)
 
-#define FreeSysInfo(si)                                                                                           \
-	({                                                                                                            \
-		struct SysInfo *_FreeSysInfo_si = (si);                                                                   \
-		({                                                                                                        \
-			register char *_FreeSysInfo__bn __asm("a6") = (char *)(SYSINFO_BASE_NAME);                            \
-			((void (*)(char *__asm("a6"), struct SysInfo *__asm("a0")))(_FreeSysInfo__bn - 36))(_FreeSysInfo__bn, \
-																								_FreeSysInfo_si); \
-		});                                                                                                       \
-	})
+#define FreeSysInfo(si) \
+	LP1NR(0x24, FreeSysInfo, struct SysInfo *, si, a0, , SYSINFO_BASE_NAME)
 
-#define GetLoadAverage(si, la)                                                                               \
-	({                                                                                                       \
-		struct SysInfo *_GetLoadAverage_si = (si);                                                           \
-		struct SI_LoadAverage *_GetLoadAverage_la = (la);                                                    \
-		({                                                                                                   \
-			register char *_GetLoadAverage__bn __asm("a6") = (char *)(SYSINFO_BASE_NAME);                    \
-			((void (*)(char *__asm("a6"), struct SysInfo *__asm("a0"), struct SI_LoadAverage *__asm("a1")))( \
-				_GetLoadAverage__bn - 42))(_GetLoadAverage__bn, _GetLoadAverage_si, _GetLoadAverage_la);     \
-		});                                                                                                  \
-	})
+#define GetLoadAverage(si, la) \
+	LP2NR(0x2a, GetLoadAverage, struct SysInfo *, si, a0, struct SI_LoadAverage *, la, a1, , SYSINFO_BASE_NAME)
 
-#define GetPid(si)                                                                                                  \
-	({                                                                                                              \
-		struct SysInfo *_GetPid_si = (si);                                                                          \
-		({                                                                                                          \
-			register char *_GetPid__bn __asm("a6") = (char *)(SYSINFO_BASE_NAME);                                   \
-			((LONG(*)(char *__asm("a6"), struct SysInfo *__asm("a0")))(_GetPid__bn - 48))(_GetPid__bn, _GetPid_si); \
-		});                                                                                                         \
-	})
+#define GetPid(si) \
+	LP1(0x30, LONG, GetPid, struct SysInfo *, si, a0, , SYSINFO_BASE_NAME)
 
-#define GetPpid(si)                                                                                                    \
-	({                                                                                                                 \
-		struct SysInfo *_GetPpid_si = (si);                                                                            \
-		({                                                                                                             \
-			register char *_GetPpid__bn __asm("a6") = (char *)(SYSINFO_BASE_NAME);                                     \
-			((LONG(*)(char *__asm("a6"), struct SysInfo *__asm("a0")))(_GetPpid__bn - 54))(_GetPpid__bn, _GetPpid_si); \
-		});                                                                                                            \
-	})
+#define GetPpid(si) \
+	LP1(0x36, LONG, GetPpid, struct SysInfo *, si, a0, , SYSINFO_BASE_NAME)
 
-#define GetPgrp(si)                                                                                                    \
-	({                                                                                                                 \
-		struct SysInfo *_GetPgrp_si = (si);                                                                            \
-		({                                                                                                             \
-			register char *_GetPgrp__bn __asm("a6") = (char *)(SYSINFO_BASE_NAME);                                     \
-			((LONG(*)(char *__asm("a6"), struct SysInfo *__asm("a0")))(_GetPgrp__bn - 60))(_GetPgrp__bn, _GetPgrp_si); \
-		});                                                                                                            \
-	})
+#define GetPgrp(si) \
+	LP1(0x3c, LONG, GetPgrp, struct SysInfo *, si, a0, , SYSINFO_BASE_NAME)
 
-#define GetNice(si, which, who)                                                                             \
-	({                                                                                                      \
-		struct SysInfo *_GetNice_si = (si);                                                                 \
-		LONG _GetNice_which = (which);                                                                      \
-		LONG _GetNice_who = (who);                                                                          \
-		({                                                                                                  \
-			register char *_GetNice__bn __asm("a6") = (char *)(SYSINFO_BASE_NAME);                          \
-			((LONG(*)(char *__asm("a6"), struct SysInfo *__asm("a0"), LONG __asm("d0"), LONG __asm("d1")))( \
-				_GetNice__bn - 66))(_GetNice__bn, _GetNice_si, _GetNice_which, _GetNice_who);               \
-		});                                                                                                 \
-	})
+#define GetNice(si, which, who) \
+	LP3(0x42, LONG, GetNice, struct SysInfo *, si, a0, LONG, which, d0, LONG, who, d1, , SYSINFO_BASE_NAME)
 
-#define SetNice(si, which, who, nice)                                                    \
-	({                                                                                   \
-		struct SysInfo *_SetNice_si = (si);                                              \
-		LONG _SetNice_which = (which);                                                   \
-		LONG _SetNice_who = (who);                                                       \
-		LONG _SetNice_nice = (nice);                                                     \
-		({                                                                               \
-			register char *_SetNice__bn __asm("a6") = (char *)(SYSINFO_BASE_NAME);       \
-			((LONG(*)(char *__asm("a6"),                                                 \
-					  struct SysInfo *__asm("a0"),                                       \
-					  LONG __asm("d0"),                                                  \
-					  LONG __asm("d1"),                                                  \
-					  LONG __asm("d2")))(_SetNice__bn - 72))(                            \
-				_SetNice__bn, _SetNice_si, _SetNice_which, _SetNice_who, _SetNice_nice); \
-		});                                                                              \
-	})
+#define SetNice(si, which, who, nice) \
+	LP4(0x48, LONG, SetNice, struct SysInfo *, si, a0, LONG, which, d0, LONG, who, d1, LONG, nice, d2, , SYSINFO_BASE_NAME)
 
-#define AddNotify(si, flags, safety_limit)                                                                       \
-	({                                                                                                           \
-		struct SysInfo *_AddNotify_si = (si);                                                                    \
-		WORD _AddNotify_flags = (flags);                                                                         \
-		LONG _AddNotify_safety_limit = (safety_limit);                                                           \
-		({                                                                                                       \
-			register char *_AddNotify__bn __asm("a6") = (char *)(SYSINFO_BASE_NAME);                             \
-			((struct SI_Notify *                                                                                 \
-			  (*)(char *__asm("a6"), struct SysInfo *__asm("a0"), WORD __asm("d0"), LONG __asm("d1")))(          \
-				_AddNotify__bn - 78))(_AddNotify__bn, _AddNotify_si, _AddNotify_flags, _AddNotify_safety_limit); \
-		});                                                                                                      \
-	})
+#define AddNotify(si, flags, safety_limit) \
+	LP3(0x4e, struct SI_Notify *, AddNotify, struct SysInfo *, si, a0, WORD, flags, d0, LONG, safety_limit, d1, , SYSINFO_BASE_NAME)
 
-#define RemoveNotify(si, notify)                                                                        \
-	({                                                                                                  \
-		struct SysInfo *_RemoveNotify_si = (si);                                                        \
-		struct SI_Notify *_RemoveNotify_notify = (notify);                                              \
-		({                                                                                              \
-			register char *_RemoveNotify__bn __asm("a6") = (char *)(SYSINFO_BASE_NAME);                 \
-			((void (*)(char *__asm("a6"), struct SysInfo *__asm("a0"), struct SI_Notify *__asm("a1")))( \
-				_RemoveNotify__bn - 84))(_RemoveNotify__bn, _RemoveNotify_si, _RemoveNotify_notify);    \
-		});                                                                                             \
-	})
+#define RemoveNotify(si, notify) \
+	LP2NR(0x54, RemoveNotify, struct SysInfo *, si, a0, struct SI_Notify *, notify, a1, , SYSINFO_BASE_NAME)
 
-#define GetCpuUsage(si, usage)                                                                            \
-	({                                                                                                    \
-		struct SysInfo *_GetCpuUsage_si = (si);                                                           \
-		struct SI_CpuUsage *_GetCpuUsage_usage = (usage);                                                 \
-		({                                                                                                \
-			register char *_GetCpuUsage__bn __asm("a6") = (char *)(SYSINFO_BASE_NAME);                    \
-			((void (*)(char *__asm("a6"), struct SysInfo *__asm("a0"), struct SI_CpuUsage *__asm("a1")))( \
-				_GetCpuUsage__bn - 90))(_GetCpuUsage__bn, _GetCpuUsage_si, _GetCpuUsage_usage);           \
-		});                                                                                               \
-	})
+#define GetCpuUsage(si, usage) \
+	LP2NR(0x5a, GetCpuUsage, struct SysInfo *, si, a0, struct SI_CpuUsage *, usage, a1, , SYSINFO_BASE_NAME)
 
-#define GetTaskCpuUsage(si, usage, task)                                                                   \
-	({                                                                                                     \
-		struct SysInfo *_GetTaskCpuUsage_si = (si);                                                        \
-		struct SI_TaskCpuUsage *_GetTaskCpuUsage_usage = (usage);                                          \
-		struct Task *_GetTaskCpuUsage_task = (task);                                                       \
-		({                                                                                                 \
-			register char *_GetTaskCpuUsage__bn __asm("a6") = (char *)(SYSINFO_BASE_NAME);                 \
-			((LONG(*)(char *__asm("a6"),                                                                   \
-					  struct SysInfo *__asm("a0"),                                                         \
-					  struct SI_TaskCpuUsage *__asm("a1"),                                                 \
-					  struct Task *__asm("a2")))(_GetTaskCpuUsage__bn - 96))(                              \
-				_GetTaskCpuUsage__bn, _GetTaskCpuUsage_si, _GetTaskCpuUsage_usage, _GetTaskCpuUsage_task); \
-		});                                                                                                \
-	})
+#define GetTaskCpuUsage(si, usage, task) \
+	LP3(0x60, LONG, GetTaskCpuUsage, struct SysInfo *, si, a0, struct SI_TaskCpuUsage *, usage, a1, struct Task *, task, a2, , SYSINFO_BASE_NAME)
 
 #endif /*  _INLINE_SYSINFO_H  */

--- a/source/Include/inline/multiuser.h
+++ b/source/Include/inline/multiuser.h
@@ -5,6 +5,10 @@
 	#define CLIB_MULTIUSER_PROTOS_H
 #endif
 
+#ifndef __INLINE_MACROS_H
+	#include <inline/macros.h>
+#endif
+
 #ifndef LIBRARIES_MULTIUSER_H
 	#include <libraries/multiuser.h>
 #endif
@@ -13,15 +17,8 @@
 	#define MULTIUSER_BASE_NAME muBase
 #endif
 
-#define muLogoutA(taglist)                                                                                         \
-	({                                                                                                             \
-		struct TagItem *_muLogoutA_taglist = (taglist);                                                            \
-		({                                                                                                         \
-			register char *_muLogoutA__bn __asm("a6") = (char *)(MULTIUSER_BASE_NAME);                             \
-			((ULONG(*)(char *__asm("a6"), struct TagItem *__asm("a0")))(_muLogoutA__bn - 30))(_muLogoutA__bn,      \
-																							  _muLogoutA_taglist); \
-		});                                                                                                        \
-	})
+#define muLogoutA(taglist) \
+	LP1(0x1e, ULONG, muLogoutA, struct TagItem *, taglist, a0, , MULTIUSER_BASE_NAME)
 
 #ifndef NO_INLINE_STDARG
 static __inline__ ULONG ___muLogout(struct Library *muBase, ULONG taglist, ...)
@@ -32,15 +29,8 @@ static __inline__ ULONG ___muLogout(struct Library *muBase, ULONG taglist, ...)
 	#define muLogout(tags...) ___muLogout(MULTIUSER_BASE_NAME, tags)
 #endif
 
-#define muLoginA(taglist)                                                                                        \
-	({                                                                                                           \
-		struct TagItem *_muLoginA_taglist = (taglist);                                                           \
-		({                                                                                                       \
-			register char *_muLoginA__bn __asm("a6") = (char *)(MULTIUSER_BASE_NAME);                            \
-			((ULONG(*)(char *__asm("a6"), struct TagItem *__asm("a0")))(_muLoginA__bn - 36))(_muLoginA__bn,      \
-																							 _muLoginA_taglist); \
-		});                                                                                                      \
-	})
+#define muLoginA(taglist) \
+	LP1(0x24, ULONG, muLoginA, struct TagItem *, taglist, a0, , MULTIUSER_BASE_NAME)
 
 #ifndef NO_INLINE_STDARG
 static __inline__ ULONG ___muLogin(struct Library *muBase, ULONG taglist, ...)
@@ -51,63 +41,23 @@ static __inline__ ULONG ___muLogin(struct Library *muBase, ULONG taglist, ...)
 	#define muLogin(tags...) ___muLogin(MULTIUSER_BASE_NAME, tags)
 #endif
 
-#define muGetTaskOwner(task)                                                                                           \
-	({                                                                                                                 \
-		struct Task *_muGetTaskOwner_task = (task);                                                                    \
-		({                                                                                                             \
-			register char *_muGetTaskOwner__bn __asm("a6") = (char *)(MULTIUSER_BASE_NAME);                            \
-			((ULONG(*)(char *__asm("a6"), struct Task *__asm("d0")))(_muGetTaskOwner__bn - 42))(_muGetTaskOwner__bn,   \
-																								_muGetTaskOwner_task); \
-		});                                                                                                            \
-	})
+#define muGetTaskOwner(task) \
+	LP1(0x2a, ULONG, muGetTaskOwner, struct Task *, task, d0, , MULTIUSER_BASE_NAME)
 
-#define muPasswd(oldpwd, newpwd)                                                                        \
-	({                                                                                                  \
-		STRPTR _muPasswd_oldpwd = (oldpwd);                                                             \
-		STRPTR _muPasswd_newpwd = (newpwd);                                                             \
-		({                                                                                              \
-			register char *_muPasswd__bn __asm("a6") = (char *)(MULTIUSER_BASE_NAME);                   \
-			((BOOL(*)(char *__asm("a6"), STRPTR __asm("a0"), STRPTR __asm("a1")))(_muPasswd__bn - 48))( \
-				_muPasswd__bn, _muPasswd_oldpwd, _muPasswd_newpwd);                                     \
-		});                                                                                             \
-	})
+#define muPasswd(oldpwd, newpwd) \
+	LP2(0x30, BOOL, muPasswd, STRPTR, oldpwd, a0, STRPTR, newpwd, a1, , MULTIUSER_BASE_NAME)
 
-#define muAllocUserInfo()                                                                                \
-	({                                                                                                   \
-		register char *_muAllocUserInfo__bn __asm("a6") = (char *)(MULTIUSER_BASE_NAME);                 \
-		((struct muUserInfo * (*)(char *__asm("a6")))(_muAllocUserInfo__bn - 54))(_muAllocUserInfo__bn); \
-	})
+#define muAllocUserInfo() \
+	LP0(0x36, struct muUserInfo *, muAllocUserInfo, , MULTIUSER_BASE_NAME)
 
-#define muFreeUserInfo(info)                                                                           \
-	({                                                                                                 \
-		struct muUserInfo *_muFreeUserInfo_info = (info);                                              \
-		({                                                                                             \
-			register char *_muFreeUserInfo__bn __asm("a6") = (char *)(MULTIUSER_BASE_NAME);            \
-			((void (*)(char *__asm("a6"), struct muUserInfo *__asm("a0")))(_muFreeUserInfo__bn - 60))( \
-				_muFreeUserInfo__bn, _muFreeUserInfo_info);                                            \
-		});                                                                                            \
-	})
+#define muFreeUserInfo(info) \
+	LP1NR(0x3c, muFreeUserInfo, struct muUserInfo *, info, a0, , MULTIUSER_BASE_NAME)
 
-#define muGetUserInfo(info, keytype)                                                                          \
-	({                                                                                                        \
-		struct muUserInfo *_muGetUserInfo_info = (info);                                                      \
-		ULONG _muGetUserInfo_keytype = (keytype);                                                             \
-		({                                                                                                    \
-			register char *_muGetUserInfo__bn __asm("a6") = (char *)(MULTIUSER_BASE_NAME);                    \
-			((struct muUserInfo * (*)(char *__asm("a6"), struct muUserInfo *__asm("a0"), ULONG __asm("d0")))( \
-				_muGetUserInfo__bn - 66))(_muGetUserInfo__bn, _muGetUserInfo_info, _muGetUserInfo_keytype);   \
-		});                                                                                                   \
-	})
+#define muGetUserInfo(info, keytype) \
+	LP2(0x42, struct muUserInfo *, muGetUserInfo, struct muUserInfo *, info, a0, ULONG, keytype, d0, , MULTIUSER_BASE_NAME)
 
-#define muSetDefProtectionA(taglist)                                                                    \
-	({                                                                                                  \
-		struct TagItem *_muSetDefProtectionA_taglist = (taglist);                                       \
-		({                                                                                              \
-			register char *_muSetDefProtectionA__bn __asm("a6") = (char *)(MULTIUSER_BASE_NAME);        \
-			((BOOL(*)(char *__asm("a6"), struct TagItem *__asm("a0")))(_muSetDefProtectionA__bn - 78))( \
-				_muSetDefProtectionA__bn, _muSetDefProtectionA_taglist);                                \
-		});                                                                                             \
-	})
+#define muSetDefProtectionA(taglist) \
+	LP1(0x4e, BOOL, muSetDefProtectionA, struct TagItem *, taglist, a0, , MULTIUSER_BASE_NAME)
 
 #ifndef NO_INLINE_STDARG
 static __inline__ BOOL ___muSetDefProtection(struct Library *muBase, ULONG taglist, ...)
@@ -118,46 +68,17 @@ static __inline__ BOOL ___muSetDefProtection(struct Library *muBase, ULONG tagli
 	#define muSetDefProtection(tags...) ___muSetDefProtection(MULTIUSER_BASE_NAME, tags)
 #endif
 
-#define muGetDefProtection(task)                                                                     \
-	({                                                                                               \
-		struct Task *_muGetDefProtection_task = (task);                                              \
-		({                                                                                           \
-			register char *_muGetDefProtection__bn __asm("a6") = (char *)(MULTIUSER_BASE_NAME);      \
-			((ULONG(*)(char *__asm("a6"), struct Task *__asm("d0")))(_muGetDefProtection__bn - 84))( \
-				_muGetDefProtection__bn, _muGetDefProtection_task);                                  \
-		});                                                                                          \
-	})
+#define muGetDefProtection(task) \
+	LP1(0x54, ULONG, muGetDefProtection, struct Task *, task, d0, , MULTIUSER_BASE_NAME)
 
-#define muSetProtection(name, mask)                                                                          \
-	({                                                                                                       \
-		STRPTR _muSetProtection_name = (name);                                                               \
-		LONG _muSetProtection_mask = (mask);                                                                 \
-		({                                                                                                   \
-			register char *_muSetProtection__bn __asm("a6") = (char *)(MULTIUSER_BASE_NAME);                 \
-			((BOOL(*)(char *__asm("a6"), STRPTR __asm("d1"), LONG __asm("d2")))(_muSetProtection__bn - 90))( \
-				_muSetProtection__bn, _muSetProtection_name, _muSetProtection_mask);                         \
-		});                                                                                                  \
-	})
+#define muSetProtection(name, mask) \
+	LP2(0x5a, BOOL, muSetProtection, STRPTR, name, d1, LONG, mask, d2, , MULTIUSER_BASE_NAME)
 
-#define muLimitDOSSetProtection(flag)                                                                \
-	({                                                                                               \
-		BOOL _muLimitDOSSetProtection_flag = (flag);                                                 \
-		({                                                                                           \
-			register char *_muLimitDOSSetProtection__bn __asm("a6") = (char *)(MULTIUSER_BASE_NAME); \
-			((BOOL(*)(char *__asm("a6"), BOOL __asm("d0")))(_muLimitDOSSetProtection__bn - 96))(     \
-				_muLimitDOSSetProtection__bn, _muLimitDOSSetProtection_flag);                        \
-		});                                                                                          \
-	})
+#define muLimitDOSSetProtection(flag) \
+	LP1(0x60, BOOL, muLimitDOSSetProtection, BOOL, flag, d0, , MULTIUSER_BASE_NAME)
 
-#define muCheckPasswd(taglist)                                                                     \
-	({                                                                                             \
-		struct TagItem *_muCheckPasswd_taglist = (taglist);                                        \
-		({                                                                                         \
-			register char *_muCheckPasswd__bn __asm("a6") = (char *)(MULTIUSER_BASE_NAME);         \
-			((BOOL(*)(char *__asm("a6"), struct TagItem *__asm("a0")))(_muCheckPasswd__bn - 102))( \
-				_muCheckPasswd__bn, _muCheckPasswd_taglist);                                       \
-		});                                                                                        \
-	})
+#define muCheckPasswd(taglist) \
+	LP1(0x66, BOOL, muCheckPasswd, struct TagItem *, taglist, a0, , MULTIUSER_BASE_NAME)
 
 #ifndef NO_INLINE_STDARG
 static __inline__ BOOL ___muCheckPasswdTags(struct Library *muBase, ULONG taglist, ...)
@@ -168,53 +89,20 @@ static __inline__ BOOL ___muCheckPasswdTags(struct Library *muBase, ULONG taglis
 	#define muCheckPasswdTags(tags...) ___muCheckPasswdTags(MULTIUSER_BASE_NAME, tags)
 #endif
 
-#define muGetPasswdDirLock()                                                                    \
-	({                                                                                          \
-		register char *_muGetPasswdDirLock__bn __asm("a6") = (char *)(MULTIUSER_BASE_NAME);     \
-		((BPTR(*)(char *__asm("a6")))(_muGetPasswdDirLock__bn - 114))(_muGetPasswdDirLock__bn); \
-	})
+#define muGetPasswdDirLock() \
+	LP0(0x72, BPTR, muGetPasswdDirLock, , MULTIUSER_BASE_NAME)
 
-#define muGetConfigDirLock()                                                                    \
-	({                                                                                          \
-		register char *_muGetConfigDirLock__bn __asm("a6") = (char *)(MULTIUSER_BASE_NAME);     \
-		((BPTR(*)(char *__asm("a6")))(_muGetConfigDirLock__bn - 120))(_muGetConfigDirLock__bn); \
-	})
+#define muGetConfigDirLock() \
+	LP0(0x78, BPTR, muGetConfigDirLock, , MULTIUSER_BASE_NAME)
 
-#define muGetTaskExtOwner(task)                                                                                     \
-	({                                                                                                              \
-		struct Task *_muGetTaskExtOwner_task = (task);                                                              \
-		({                                                                                                          \
-			register char *_muGetTaskExtOwner__bn __asm("a6") = (char *)(MULTIUSER_BASE_NAME);                      \
-			((struct muExtOwner * (*)(char *__asm("a6"), struct Task *__asm("d0")))(_muGetTaskExtOwner__bn - 126))( \
-				_muGetTaskExtOwner__bn, _muGetTaskExtOwner_task);                                                   \
-		});                                                                                                         \
-	})
+#define muGetTaskExtOwner(task) \
+	LP1(0x7e, struct muExtOwner *, muGetTaskExtOwner, struct Task *, task, d0, , MULTIUSER_BASE_NAME)
 
-#define muFreeExtOwner(info)                                                                            \
-	({                                                                                                  \
-		struct muExtOwner *_muFreeExtOwner_info = (info);                                               \
-		({                                                                                              \
-			register char *_muFreeExtOwner__bn __asm("a6") = (char *)(MULTIUSER_BASE_NAME);             \
-			((void (*)(char *__asm("a6"), struct muExtOwner *__asm("a0")))(_muFreeExtOwner__bn - 132))( \
-				_muFreeExtOwner__bn, _muFreeExtOwner_info);                                             \
-		});                                                                                             \
-	})
+#define muFreeExtOwner(info) \
+	LP1NR(0x84, muFreeExtOwner, struct muExtOwner *, info, a0, , MULTIUSER_BASE_NAME)
 
-#define muGetRelationshipA(user, owner, taglist)                                                                     \
-	({                                                                                                               \
-		struct muExtOwner *_muGetRelationshipA_user = (user);                                                        \
-		ULONG _muGetRelationshipA_owner = (owner);                                                                   \
-		struct TagItem *_muGetRelationshipA_taglist = (taglist);                                                     \
-		({                                                                                                           \
-			register char *_muGetRelationshipA__bn __asm("a6") = (char *)(MULTIUSER_BASE_NAME);                      \
-			((ULONG(*)(                                                                                              \
-				char *__asm("a6"), struct muExtOwner *__asm("d0"), ULONG __asm("d1"), struct TagItem *__asm("a0")))( \
-				_muGetRelationshipA__bn - 138))(_muGetRelationshipA__bn,                                             \
-												_muGetRelationshipA_user,                                            \
-												_muGetRelationshipA_owner,                                           \
-												_muGetRelationshipA_taglist);                                        \
-		});                                                                                                          \
-	})
+#define muGetRelationshipA(user, owner, taglist) \
+	LP3(0x8a, ULONG, muGetRelationshipA, struct muExtOwner *, user, d0, ULONG, owner, d1, struct TagItem *, taglist, a0, , MULTIUSER_BASE_NAME)
 
 #ifndef NO_INLINE_STDARG
 static __inline__ ULONG ___muGetRelationship(struct Library *muBase,
@@ -229,90 +117,31 @@ static __inline__ ULONG ___muGetRelationship(struct Library *muBase,
 	#define muGetRelationship(user, owner...) ___muGetRelationship(MULTIUSER_BASE_NAME, user, owner)
 #endif
 
-#define muUserInfo2ExtOwner(info)                                                                      \
-	({                                                                                                 \
-		struct muUserInfo *_muUserInfo2ExtOwner_info = (info);                                         \
-		({                                                                                             \
-			register char *_muUserInfo2ExtOwner__bn __asm("a6") = (char *)(MULTIUSER_BASE_NAME);       \
-			((struct muExtOwner * (*)(char *__asm("a6"), struct muUserInfo *__asm("a0")))(             \
-				_muUserInfo2ExtOwner__bn - 144))(_muUserInfo2ExtOwner__bn, _muUserInfo2ExtOwner_info); \
-		});                                                                                            \
-	})
+#define muUserInfo2ExtOwner(info) \
+	LP1(0x90, struct muExtOwner *, muUserInfo2ExtOwner, struct muUserInfo *, info, a0, , MULTIUSER_BASE_NAME)
 
-#define muAllocGroupInfo()                                                                                   \
-	({                                                                                                       \
-		register char *_muAllocGroupInfo__bn __asm("a6") = (char *)(MULTIUSER_BASE_NAME);                    \
-		((struct muGroupInfo * (*)(char *__asm("a6")))(_muAllocGroupInfo__bn - 150))(_muAllocGroupInfo__bn); \
-	})
+#define muAllocGroupInfo() \
+	LP0(0x96, struct muGroupInfo *, muAllocGroupInfo, , MULTIUSER_BASE_NAME)
 
-#define muFreeGroupInfo(info)                                                                             \
-	({                                                                                                    \
-		struct muGroupInfo *_muFreeGroupInfo_info = (info);                                               \
-		({                                                                                                \
-			register char *_muFreeGroupInfo__bn __asm("a6") = (char *)(MULTIUSER_BASE_NAME);              \
-			((void (*)(char *__asm("a6"), struct muGroupInfo *__asm("a0")))(_muFreeGroupInfo__bn - 156))( \
-				_muFreeGroupInfo__bn, _muFreeGroupInfo_info);                                             \
-		});                                                                                               \
-	})
+#define muFreeGroupInfo(info) \
+	LP1NR(0x9c, muFreeGroupInfo, struct muGroupInfo *, info, a0, , MULTIUSER_BASE_NAME)
 
-#define muGetGroupInfo(info, keytype)                                                                            \
-	({                                                                                                           \
-		struct muGroupInfo *_muGetGroupInfo_info = (info);                                                       \
-		ULONG _muGetGroupInfo_keytype = (keytype);                                                               \
-		({                                                                                                       \
-			register char *_muGetGroupInfo__bn __asm("a6") = (char *)(MULTIUSER_BASE_NAME);                      \
-			((struct muGroupInfo * (*)(char *__asm("a6"), struct muGroupInfo *__asm("a0"), ULONG __asm("d0")))(  \
-				_muGetGroupInfo__bn - 162))(_muGetGroupInfo__bn, _muGetGroupInfo_info, _muGetGroupInfo_keytype); \
-		});                                                                                                      \
-	})
+#define muGetGroupInfo(info, keytype) \
+	LP2(0xa2, struct muGroupInfo *, muGetGroupInfo, struct muGroupInfo *, info, a0, ULONG, keytype, d0, , MULTIUSER_BASE_NAME)
 
-#define muAddMonitor(monitor)                                                                       \
-	({                                                                                              \
-		struct muMonitor *_muAddMonitor_monitor = (monitor);                                        \
-		({                                                                                          \
-			register char *_muAddMonitor__bn __asm("a6") = (char *)(MULTIUSER_BASE_NAME);           \
-			((BOOL(*)(char *__asm("a6"), struct muMonitor *__asm("a0")))(_muAddMonitor__bn - 168))( \
-				_muAddMonitor__bn, _muAddMonitor_monitor);                                          \
-		});                                                                                         \
-	})
+#define muAddMonitor(monitor) \
+	LP1(0xa8, BOOL, muAddMonitor, struct muMonitor *, monitor, a0, , MULTIUSER_BASE_NAME)
 
-#define muRemMonitor(monitor)                                                                        \
-	({                                                                                               \
-		struct muMonitor *_muRemMonitor_monitor = (monitor);                                         \
-		({                                                                                           \
-			register char *_muRemMonitor__bn __asm("a6") = (char *)(MULTIUSER_BASE_NAME);            \
-			((void (*)(char *__asm("a6"), struct muMonitor *__asm("a0")))(_muRemMonitor__bn - 174))( \
-				_muRemMonitor__bn, _muRemMonitor_monitor);                                           \
-		});                                                                                          \
-	})
+#define muRemMonitor(monitor) \
+	LP1NR(0xae, muRemMonitor, struct muMonitor *, monitor, a0, , MULTIUSER_BASE_NAME)
 
-#define muKill(task)                                                                                                \
-	({                                                                                                              \
-		struct Task *_muKill_task = (task);                                                                         \
-		({                                                                                                          \
-			register char *_muKill__bn __asm("a6") = (char *)(MULTIUSER_BASE_NAME);                                 \
-			((BOOL(*)(char *__asm("a6"), struct Task *__asm("d0")))(_muKill__bn - 180))(_muKill__bn, _muKill_task); \
-		});                                                                                                         \
-	})
+#define muKill(task) \
+	LP1(0xb4, BOOL, muKill, struct Task *, task, d0, , MULTIUSER_BASE_NAME)
 
-#define muFreeze(task)                                                                                     \
-	({                                                                                                     \
-		struct Task *_muFreeze_task = (task);                                                              \
-		({                                                                                                 \
-			register char *_muFreeze__bn __asm("a6") = (char *)(MULTIUSER_BASE_NAME);                      \
-			((BOOL(*)(char *__asm("a6"), struct Task *__asm("d0")))(_muFreeze__bn - 186))(_muFreeze__bn,   \
-																						  _muFreeze_task); \
-		});                                                                                                \
-	})
+#define muFreeze(task) \
+	LP1(0xba, BOOL, muFreeze, struct Task *, task, d0, , MULTIUSER_BASE_NAME)
 
-#define muUnfreeze(task)                                                                                       \
-	({                                                                                                         \
-		struct Task *_muUnfreeze_task = (task);                                                                \
-		({                                                                                                     \
-			register char *_muUnfreeze__bn __asm("a6") = (char *)(MULTIUSER_BASE_NAME);                        \
-			((BOOL(*)(char *__asm("a6"), struct Task *__asm("d0")))(_muUnfreeze__bn - 192))(_muUnfreeze__bn,   \
-																							_muUnfreeze_task); \
-		});                                                                                                    \
-	})
+#define muUnfreeze(task) \
+	LP1(0xc0, BOOL, muUnfreeze, struct Task *, task, d0, , MULTIUSER_BASE_NAME)
 
 #endif /*  _INLINE_MULTIUSER_H  */

--- a/source/Include/inline/newicon.h
+++ b/source/Include/inline/newicon.h
@@ -5,6 +5,10 @@
 	#define CLIB_NEWICON_PROTOS_H
 #endif
 
+#ifndef __INLINE_MACROS_H
+	#include <inline/macros.h>
+#endif
+
 #ifndef EXEC_TYPES_H
 	#include <exec/types.h>
 #endif
@@ -20,71 +24,23 @@ extern "C" {
 	#define NEWICON_BASE_NAME NewIconBase
 #endif
 
-#define GetNewDiskObject(name)                                                                                 \
-	({                                                                                                         \
-		UBYTE *_GetNewDiskObject_name = (name);                                                                \
-		({                                                                                                     \
-			register char *_GetNewDiskObject__bn __asm("a6") = (char *)(NEWICON_BASE_NAME);                    \
-			((struct NewDiskObject * (*)(char *__asm("a6"), UBYTE *__asm("a0")))(_GetNewDiskObject__bn - 30))( \
-				_GetNewDiskObject__bn, _GetNewDiskObject_name);                                                \
-		});                                                                                                    \
-	})
+#define GetNewDiskObject(name) \
+	LP1(0x1e, struct NewDiskObject *, GetNewDiskObject, UBYTE *, name, a0, , NEWICON_BASE_NAME)
 
-#define PutNewDiskObject(name, newdiskobj)                                                        \
-	({                                                                                            \
-		UBYTE *_PutNewDiskObject_name = (name);                                                   \
-		struct NewDiskObject *_PutNewDiskObject_newdiskobj = (newdiskobj);                        \
-		({                                                                                        \
-			register char *_PutNewDiskObject__bn __asm("a6") = (char *)(NEWICON_BASE_NAME);       \
-			((BOOL(*)(char *__asm("a6"), UBYTE *__asm("a0"), struct NewDiskObject *__asm("a1")))( \
-				_PutNewDiskObject__bn - 36))(                                                     \
-				_PutNewDiskObject__bn, _PutNewDiskObject_name, _PutNewDiskObject_newdiskobj);     \
-		});                                                                                       \
-	})
+#define PutNewDiskObject(name, newdiskobj) \
+	LP2(0x24, BOOL, PutNewDiskObject, UBYTE *, name, a0, struct NewDiskObject *, newdiskobj, a1, , NEWICON_BASE_NAME)
 
-#define FreeNewDiskObject(newdiskobj)                                                                        \
-	({                                                                                                       \
-		struct NewDiskObject *_FreeNewDiskObject_newdiskobj = (newdiskobj);                                  \
-		({                                                                                                   \
-			register char *_FreeNewDiskObject__bn __asm("a6") = (char *)(NEWICON_BASE_NAME);                 \
-			((void (*)(char *__asm("a6"), struct NewDiskObject *__asm("a0")))(_FreeNewDiskObject__bn - 42))( \
-				_FreeNewDiskObject__bn, _FreeNewDiskObject_newdiskobj);                                      \
-		});                                                                                                  \
-	})
+#define FreeNewDiskObject(newdiskobj) \
+	LP1NR(0x2a, FreeNewDiskObject, struct NewDiskObject *, newdiskobj, a0, , NEWICON_BASE_NAME)
 
-#define RemapChunkyImage(chunkyimage, screen)                                                                      \
-	({                                                                                                             \
-		struct ChunkyImage *_RemapChunkyImage_chunkyimage = (chunkyimage);                                         \
-		struct Screen *_RemapChunkyImage_screen = (screen);                                                        \
-		({                                                                                                         \
-			register char *_RemapChunkyImage__bn __asm("a6") = (char *)(NEWICON_BASE_NAME);                        \
-			((struct Image * (*)(char *__asm("a6"), struct ChunkyImage *__asm("a0"), struct Screen *__asm("a1")))( \
-				_RemapChunkyImage__bn - 66))(                                                                      \
-				_RemapChunkyImage__bn, _RemapChunkyImage_chunkyimage, _RemapChunkyImage_screen);                   \
-		});                                                                                                        \
-	})
+#define RemapChunkyImage(chunkyimage, screen) \
+	LP2(0x42, struct Image *, RemapChunkyImage, struct ChunkyImage *, chunkyimage, a0, struct Screen *, screen, a1, , NEWICON_BASE_NAME)
 
-#define FreeRemappedImage(image, screen)                                                          \
-	({                                                                                            \
-		struct Image *_FreeRemappedImage_image = (image);                                         \
-		struct Screen *_FreeRemappedImage_screen = (screen);                                      \
-		({                                                                                        \
-			register char *_FreeRemappedImage__bn __asm("a6") = (char *)(NEWICON_BASE_NAME);      \
-			((VOID(*)(char *__asm("a6"), struct Image *__asm("a0"), struct Screen *__asm("a1")))( \
-				_FreeRemappedImage__bn - 72))(                                                    \
-				_FreeRemappedImage__bn, _FreeRemappedImage_image, _FreeRemappedImage_screen);     \
-		});                                                                                       \
-	})
+#define FreeRemappedImage(image, screen) \
+	LP2NR(0x48, FreeRemappedImage, struct Image *, image, a0, struct Screen *, screen, a1, , NEWICON_BASE_NAME)
 
-#define GetDefNewDiskObject(def_type)                                                                           \
-	({                                                                                                          \
-		LONG _GetDefNewDiskObject_def_type = (def_type);                                                        \
-		({                                                                                                      \
-			register char *_GetDefNewDiskObject__bn __asm("a6") = (char *)(NEWICON_BASE_NAME);                  \
-			((struct NewDiskObject * (*)(char *__asm("a6"), LONG __asm("d0")))(_GetDefNewDiskObject__bn - 78))( \
-				_GetDefNewDiskObject__bn, _GetDefNewDiskObject_def_type);                                       \
-		});                                                                                                     \
-	})
+#define GetDefNewDiskObject(def_type) \
+	LP1(0x4e, struct NewDiskObject *, GetDefNewDiskObject, LONG, def_type, d0, , NEWICON_BASE_NAME)
 
 #ifdef __cplusplus
 }

--- a/source/Library/config_open.c
+++ b/source/Library/config_open.c
@@ -305,7 +305,11 @@ Cfg_ButtonBank *LIBFUNC L_OpenButtonBank(REG(a0, char *name))
 					if (iff_button_id == ID_OPUS)
 					{
 						if (!convert_button_window(iff, &current_bank->window))
-							return NULL;
+						{
+							L_CloseButtonBank(current_bank);
+							current_bank = 0;
+							goto bank_cleanup;
+						}
 					}
 					else
 						L_IFFReadChunkBytes(iff, &current_bank->window, sizeof(CFG_BTNW));
@@ -383,6 +387,7 @@ Cfg_ButtonBank *LIBFUNC L_OpenButtonBank(REG(a0, char *name))
 			}
 		}
 
+bank_cleanup:
 		L_IFFClose(iff);
 	}
 

--- a/source/Library/launcher.c
+++ b/source/Library/launcher.c
@@ -1045,7 +1045,7 @@ LaunchProc *launcher_launch(struct LibData *data, LaunchPacket *packet, struct M
 
 	// Change current directory
 #ifndef __AROS__
-	old_dir = CurrentDir(launch->startup.sm_ArgList[0].wa_Lock);
+	old_dir = CurrentDir(DupLock(launch->startup.sm_ArgList[0].wa_Lock));
 #endif
 
 	// Get process name
@@ -1181,7 +1181,7 @@ LaunchProc *launcher_launch(struct LibData *data, LaunchPacket *packet, struct M
 
 	// Restore current directory
 #ifndef __AROS__
-	CurrentDir(old_dir);
+	UnLock(CurrentDir(old_dir));
 #endif
 	if (cur_dir)
 		UnLock(cur_dir);

--- a/source/Library/launcher.c
+++ b/source/Library/launcher.c
@@ -917,6 +917,9 @@ void SAVEDS launcher_proc(void)
 		}
 	}
 
+	// Delete reply port
+	DeleteMsgPort(reply_port);
+
 	// Free timers
 	FreeTimer(secondtimer);
 	FreeTimer(timer);

--- a/source/Modules/configopus/fileclass_editor.c
+++ b/source/Modules/configopus/fileclass_editor.c
@@ -810,7 +810,14 @@ void classed_send_rexx(fileclass_ed_data *data, char *command, short open)
 				}
 			}
 		}
+
+		// Free the result
+		if (msg->rm_Result1 == 0 && msg->rm_Result2 != 0)
+			DeleteArgstring((char *)msg->rm_Result2);
 	}
+
+	// Clear message
+	ClearRexxMsg(msg, 1);
 
 	// Free message
 	DeleteRexxMsg(msg);

--- a/source/Modules/diskinfo/math_replace.h
+++ b/source/Modules/diskinfo/math_replace.h
@@ -36,3 +36,14 @@ float SPSincos(float *pfnum2, float fnum1)
 	*pfnum2 = cos(fnum1);
 	return (sin(fnum1));
 }
+
+/*
+ * sacredbanana/amiga-compiler libm020/libm.a(cexp.o) has undefined refs
+ * to `cimag` and `creal` (no archive member provides them). GCC 6.5.0b
+ * with -Os -flto pulls cexp.o in spuriously while merging math sections.
+ * Diskinfo never actually calls cexp — these stubs just satisfy the
+ * linker. If something ever routes through cexp, these return the real
+ * and imaginary parts correctly via GCC's __real__ / __imag__.
+ */
+double creal(double _Complex z) { return __real__ z; }
+double cimag(double _Complex z) { return __imag__ z; }

--- a/source/Modules/filetype/filetype.c
+++ b/source/Modules/filetype/filetype.c
@@ -2731,6 +2731,10 @@ static Cfg_FiletypeList *creator_generic(char *args,
 		}
 		// Free file requester
 		FreeAslRequest(data->filereq);
+
+		// Free message port
+		DeleteMsgPort(data->app_port);
+
 		FreeVec(data);
 	}
 

--- a/source/Modules/ftp/ftp_main.c
+++ b/source/Modules/ftp/ftp_main.c
@@ -3082,15 +3082,19 @@ void dopus_ftp(void)
 			// Make sure the script file has been created
 			check_script_file();
 
-			if ((rexport = CreateMsgPort()) && (nfyport = CreateMsgPort()))
+			if ((rexport = CreateMsgPort()))
 			{
 				rexbit = 1 << rexport->mp_SigBit;
-				nfybit = 1 << nfyport->mp_SigBit;
 
 				// Make the ARexx port public so Opus can find it
 				rexport->mp_Node.ln_Name = PORTNAME;
 				AddPort(rexport);
 				D(bug("**** OPUSFTP PORT ADDED ****\n"));
+			}
+
+			if (rexport && (nfyport = CreateMsgPort()))
+			{
+				nfybit = 1 << nfyport->mp_SigBit;
 
 				// Ask Opus to tell us when it will be hidden or revealed
 				if ((notify_req = AddNotifyRequest(DN_OPUS_HIDE | DN_OPUS_SHOW | DN_FLUSH_MEM, 0, nfyport)))

--- a/source/Modules/themes/themes.c
+++ b/source/Modules/themes/themes.c
@@ -414,7 +414,7 @@ long save_theme(struct Screen *screen, DOpusCallbackInfo *info, char *filename, 
 	APTR file;
 	APTR progress = 0;
 	char build_path[300];
-	struct MsgPort *reply_port;
+	struct MsgPort *reply_port = 0;
 	struct GetPointerPkt pkt;
 	Att_List *list;
 	long res = 0;
@@ -481,7 +481,11 @@ long save_theme(struct Screen *screen, DOpusCallbackInfo *info, char *filename, 
 	}
 
 	// Create a reply port
-	reply_port = CreateMsgPort();
+	if (!(reply_port = CreateMsgPort()))
+	{
+		res = 1;
+		goto cleanup;
+	}
 
 	// Write file introduction
 	write_theme_intro(file, filename);
@@ -495,9 +499,7 @@ long save_theme(struct Screen *screen, DOpusCallbackInfo *info, char *filename, 
 		!save_theme_background(file, info, "req", reply_port, build_path, progress))
 	{
 		res = IoErr();
-		CloseBuf(file);
-		CloseProgressWindow(progress);
-		return res;
+		goto cleanup;
 	}
 	WriteBuf(file, "end\n\n", -1);
 
@@ -542,11 +544,7 @@ long save_theme(struct Screen *screen, DOpusCallbackInfo *info, char *filename, 
 
 		// Failed?
 		if (res)
-		{
-			CloseBuf(file);
-			CloseProgressWindow(progress);
-			return res;
-		}
+			goto cleanup;
 	}
 	WriteBuf(file, "end\n\n", -1);
 
@@ -557,9 +555,7 @@ long save_theme(struct Screen *screen, DOpusCallbackInfo *info, char *filename, 
 		!save_theme_font(file, info, "iconsd", reply_port) || !save_theme_font(file, info, "iconsw", reply_port))
 	{
 		res = IoErr();
-		CloseBuf(file);
-		CloseProgressWindow(progress);
-		return res;
+		goto cleanup;
 	}
 	WriteBuf(file, "end\n\n", -1);
 
@@ -575,18 +571,27 @@ long save_theme(struct Screen *screen, DOpusCallbackInfo *info, char *filename, 
 	{
 		// Failure
 		res = IoErr();
-		CloseBuf(file);
-		CloseProgressWindow(progress);
-		return res;
+		goto cleanup;
 	}
 	WriteBuf(file, "end\n\n", -1);
 
 	// Write file outroduction
 	write_theme_outro(file);
 
+cleanup:
 	// Close file
 	CloseBuf(file);
 	CloseProgressWindow(progress);
+
+	// Free message port
+	if (reply_port)
+	{
+		struct Message *msg;
+		while ((msg = GetMsg(reply_port)))
+			ReplyMsg(msg);
+		DeleteMsgPort(reply_port);
+	}
+
 	return res;
 }
 

--- a/source/Modules/xadopus/XADopus.c
+++ b/source/Modules/xadopus/XADopus.c
@@ -342,22 +342,39 @@ void RemoveTemp(struct xoData *data)
 void LaunchCommand(struct xoData *data, char *cmd, char *name, char *qual)
 {
 	DOpusCallbackInfo *infoptr = &data->hook;
+	ULONG sigMask, cmdSig, timeoutTicks;
 
 	sprintf(data->buf, "lister set %s busy on wait", data->lists);
 	DC_CALL4(infoptr, dc_SendCommand, DC_REGA0, IPCDATA(data->ipc), DC_REGA1, data->buf, DC_REGA2, NULL, DC_REGD0, 0);
-	// data->hook.dc_SendCommand(IPCDATA(data->ipc),data->buf,NULL,NULL);
 	sprintf(data->buf, "dopus remtrap %s %s", cmd, data->mp_name);
 	DC_CALL4(infoptr, dc_SendCommand, DC_REGA0, IPCDATA(data->ipc), DC_REGA1, data->buf, DC_REGA2, NULL, DC_REGD0, 0);
-	// data->hook.dc_SendCommand(IPCDATA(data->ipc),data->buf,NULL,NULL);
-	sprintf(data->buf, "command wait %s %s %s", cmd, qual, name);
+
+	sprintf(data->buf, "command %s %s %s", cmd, qual, name);
+	sigMask = 1L << data->mp->mp_SigBit;
+	timeoutTicks = 30;
+
 	DC_CALL4(infoptr, dc_SendCommand, DC_REGA0, IPCDATA(data->ipc), DC_REGA1, data->buf, DC_REGA2, NULL, DC_REGD0, 0);
-	// data->hook.dc_SendCommand(IPCDATA(data->ipc),data->buf,NULL,NULL);
+
+	while (timeoutTicks > 0)
+	{
+		cmdSig = Wait(sigMask | SIGBREAKF_CTRL_C);
+		if (cmdSig & sigMask)
+		{
+			struct Message *msg;
+			while ((msg = GetMsg(data->mp)))
+				ReplyMsg(msg);
+			break;
+		}
+		if (cmdSig & SIGBREAKF_CTRL_C)
+			break;
+		timeoutTicks--;
+		Delay(50);
+	}
+
 	sprintf(data->buf, "dopus addtrap %s %s", cmd, data->mp_name);
 	DC_CALL4(infoptr, dc_SendCommand, DC_REGA0, IPCDATA(data->ipc), DC_REGA1, data->buf, DC_REGA2, NULL, DC_REGD0, 0);
-	// data->hook.dc_SendCommand(IPCDATA(data->ipc),data->buf,NULL,NULL);
 	sprintf(data->buf, "lister set %s busy off wait", data->lists);
 	DC_CALL4(infoptr, dc_SendCommand, DC_REGA0, IPCDATA(data->ipc), DC_REGA1, data->buf, DC_REGA2, NULL, DC_REGD0, 0);
-	// data->hook.dc_SendCommand(IPCDATA(data->ipc),data->buf,NULL,NULL);
 }
 
 void _scandir(struct xoData *data, char *listh, char *path)
@@ -387,8 +404,12 @@ void _doubleclick(struct xoData *data, char *name, char *qual)
 	xadERROR err;
 	BOOL retry;
 
-	while (strcmp(tmp->fib.fib_FileName, name))
+	while (tmp && strcmp(tmp->fib.fib_FileName, name))
 		tmp = tmp->Next;
+
+	// File not found in current directory
+	if (!tmp)
+		return;
 
 	if (tmp->fib.fib_DirEntryType > 0)
 	{
@@ -477,7 +498,8 @@ void _viewcommand(struct xoData *data, char *com, char *name)
 	{
 		while (tmp && (sprintf(data->buf, "\"%s\"", tmp->fib.fib_FileName)) && (!strstr(name, data->buf)))
 			tmp = tmp->Next;
-		if (tmp)
+		if (!tmp)
+			break;
 		{
 			if ((tf = AllocVec(sizeof(struct TempFile), MEMF_ANY)))
 			{
@@ -588,7 +610,8 @@ void _copy(struct xoData *data, char *name, char *Dest, BOOL CopyAs)
 	{
 		while (tmp && (sprintf(data->buf, "\"%s\"", tmp->fib.fib_FileName)) && (!strstr(name, data->buf)))
 			tmp = tmp->Next;
-		if (tmp)
+		if (!tmp)
+			break;
 		{
 			strcpy(FileName, Dest);
 			skip = FALSE;

--- a/source/Program/Module_Entry_Protocol.md
+++ b/source/Program/Module_Entry_Protocol.md
@@ -1,0 +1,91 @@
+# Directory Opus 5 - Module_Entry Execution Protocol (68k)
+
+This document describes the calling convention and data structures for the `Module_Entry` function in Directory Opus 5 on the Amiga (68k).
+
+## 1. Module Entry Point
+The primary entry point for a Directory Opus 5 module is the `Module_Entry` function (internal name `L_Module_Entry`). It is defined as follows:
+
+```c
+int LIBFUNC L_Module_Entry(
+    REG(a0, struct List *files),
+    REG(a1, struct Screen *screen),
+    REG(a2, IPCData *ipc),
+    REG(a3, IPCData *main_ipc),
+    REG(d0, ULONG mod_id),
+    REG(d1, EXT_FUNC(func_callback))
+);
+```
+
+### Reference:
+- `source/Include/defines/module.h:16`
+- `source/Include/inline/module.h:16`
+
+## 2. 68k Register Allocation
+The `Module_Entry` function uses standard Amiga library register-passing for its 6 parameters:
+
+| Register | Type | Description |
+| :--- | :--- | :--- |
+| **A0** | `struct List *` / `char *` | **Polymorphic**: Pointer to a list of files or a raw argument string. |
+| **A1** | `struct Screen *` | Pointer to the current screen for GUI operations. |
+| **A2** | `IPCData *` | The module's own IPC structure (if running as a process). |
+| **A3** | `IPCData *` | The main DOpus IPC structure for system communication. |
+| **D0** | `ULONG` | Function ID. `0xffffffff` indicates global startup/shutdown. |
+| **D1** | `EXT_FUNC` | Callback function provided by the DOpus core. |
+
+### Polymorphism in A0
+The value in `A0` depends on the module type and how it is invoked:
+- **Function Modules** (e.g., `play.module`): Typically receive a `struct List *` containing selected file entries.
+- **Command Modules** (e.g., `themes.module`): Typically receive a `char *argstring` containing raw command line arguments.
+
+Modules must determine the type of `A0` based on their `ModuleInfo` flags or the `mod_id`.
+
+## 3. Data Structures
+
+### IPCData
+Central structure for Inter-Process Communication (IPC).
+- **Definition**: `source/Include/libraries/dopus5.h:1385`
+- **Key Fields**:
+    - `command_port`: Port for receiving commands.
+    - `reply_port`: Port for sending replies.
+    - `userdata`: Module-specific data (accessible via the `IPCDATA()` macro).
+
+### IPCMessage
+Message structure sent between IPC processes.
+- **Definition**: `source/Include/libraries/dopus5.h:1366`
+
+### List / Node (Files)
+Standard Amiga `Exec/List`. Used to pass a collection of files to modules.
+- **Access**: `lh_Head` points to the first node. `ln_Name` of each node contains the file path.
+
+## 4. Core Callback Protocol (D1)
+Modules interact with the DOpus core using the `func_callback` passed in `D1`.
+
+### Signature:
+```c
+unsigned long ASM (*func_callback)(
+    REG(d0, ULONG command),
+    REG(a0, APTR handle),
+    REG(a1, APTR packet)
+);
+```
+
+### Common Commands:
+- `EXTCMD_GET_SOURCE` (0): Get current source path.
+- `EXTCMD_GET_ENTRY` (3): Get a selected file/directory entry.
+- `EXTCMD_END_ENTRY` (4): Mark an entry as processed.
+- `EXTCMD_GET_PORT` (18): Get the ARexx port name.
+
+### Reference:
+- `source/Include/libraries/module.h:80` (Enum of commands)
+- `source/Program/function_internal.c:266` (Core implementation)
+
+## 5. Return Values
+The `Module_Entry` function returns an `int` representing the result:
+- `1`: Success.
+- `0`: Failure/Error.
+- `-1`: User Abort.
+
+## 6. Calling Patterns
+- **Internal invocation**: `source/Program/function_internal.c:207`
+- **Specific handlers**: `source/Program/function_show.c:238` (for `play.module`)
+- **Global startup**: `source/Program/main.c:331` (for `update.module`)

--- a/source/Program/backdrop.h
+++ b/source/Program/backdrop.h
@@ -373,7 +373,7 @@ short backdrop_cleanup_list(BackdropInfo *info, long type);
 void backdrop_refresh_drives(BackdropInfo *info, BOOL);
 void backdrop_remove_leftouts(BackdropInfo *info, BackdropObject *disk);
 
-BOOL backdrop_test_rmb(BackdropInfo *, struct IntuiMessage *, struct IntuiMessage *, BOOL);
+BOOL backdrop_test_rmb(BackdropInfo *, struct IntuiMessage *, struct IntuiMessage *, ULONG);
 BOOL backdrop_popup(BackdropInfo *, short, short, UWORD, long, char *, DirEntry *);
 
 #define BPOPF_ICONS (1 << 0)
@@ -517,5 +517,9 @@ BOOL backdrop_goodbad_check(char *device, struct List *dos_list);
 #define CLEANUP_START_X 3
 #define CLEANUP_START_Y 7
 #define ICON_LABEL_SPACE 3
+
+#define BTRM_WINDOW   0
+#define BTRM_NOBORDER 1
+#define BTRM_ICON     2
 
 #endif

--- a/source/Program/backdrop_groups.c
+++ b/source/Program/backdrop_groups.c
@@ -522,24 +522,7 @@ IPC_EntryCode(backdrop_group_handler, static)
 					if (imsg->Class == IDCMP_MENUVERIFY)
 					{
 						// See if we want to swallow it
-						if (!backdrop_test_rmb(group->info, imsg, &msg_copy, TRUE))
-						{
-							// Did event happen over the window?
-							if (imsg->MouseX >= 0 && imsg->MouseY >= 0 && imsg->MouseX < group->window->Width &&
-								imsg->MouseY < group->window->Height && imsg->Qualifier & IEQUALIFIER_RBUTTON)
-							{
-								// Cancel menu event
-								imsg->Code = MENUCANCEL;
-
-								// Change our copy to MOUSEBUTTONS
-								msg_copy.Class = IDCMP_MOUSEBUTTONS;
-								msg_copy.Code = MENUDOWN;
-
-								// Kludge for MagicMenu
-								if (msg_copy.Seconds == 0)
-									CurrentTime(&msg_copy.Seconds, &msg_copy.Micros);
-							}
-						}
+						backdrop_test_rmb(group->info, imsg, &msg_copy, BTRM_WINDOW);
 					}
 
 					// Resize/refresh?

--- a/source/Program/backdrop_popup.c
+++ b/source/Program/backdrop_popup.c
@@ -35,7 +35,7 @@ For more information on Directory Opus for Windows please see:
 #define BPF_NOFORMAT (1 << 9)
 #define BPF_DIRECTORY (1 << 10)
 
-BOOL backdrop_test_rmb(BackdropInfo *info, struct IntuiMessage *msg, struct IntuiMessage *msg_copy, BOOL only_icon)
+BOOL backdrop_test_rmb(BackdropInfo *info, struct IntuiMessage *msg, struct IntuiMessage *msg_copy, ULONG mode)
 {
 	short x, y;
 	BOOL ret = 0;
@@ -58,8 +58,9 @@ BOOL backdrop_test_rmb(BackdropInfo *info, struct IntuiMessage *msg, struct Intu
 		lock_listlock(&info->objects, 0);
 
 		// Check if we can swallow this
-		if ((only_icon && backdrop_get_object(info, msg->MouseX, msg->MouseY, 0)) ||
-			(!only_icon && !cx_mouse_outside(info->window, msg->MouseX, msg->MouseY)))
+		if (!mode ||
+			(mode & BTRM_ICON && backdrop_get_object(info, msg->MouseX, msg->MouseY, 0)) ||
+			(mode & BTRM_NOBORDER && !cx_mouse_outside(info->window, msg->MouseX, msg->MouseY)))
 		{
 			// Cancel menu event
 			msg->Code = MENUCANCEL;

--- a/source/Program/callback_main.c
+++ b/source/Program/callback_main.c
@@ -127,6 +127,10 @@ long ASM SAVEDS HookRexxCommand(REG(a0, char *command),
 				stccpy(result, (char *)msg->rm_Result2, length);
 			rc = msg->rm_Result1;
 
+			// Free the result
+			if (msg->rm_Result1 == 0 && msg->rm_Result2 != 0)
+				DeleteArgstring((char *)msg->rm_Result2);
+
 			// Free message
 			FreeRexxMsgEx(msg);
 		}

--- a/source/Program/commands.c
+++ b/source/Program/commands.c
@@ -75,6 +75,8 @@ void update_commands(ULONG flag)
 		init_commands_scan(SCAN_USER);
 }
 
+// Initialises the module and command discovery scan.
+// See documents/dopus5/ModuleDiscovery.md for details on the discovery workflow.
 void init_commands_scan(short type)
 {
 	struct AnchorPath *anchor;
@@ -230,7 +232,8 @@ void init_commands_scan(short type)
 			{
 				ModuleInfo *info;
 
-				// Ask module to identify itself
+				// Ask module to identify itself.
+				// This retrieves module-wide metadata (name, function count, flags).
 				if ((info = Module_Identify(-1)))
 				{
 					short num;

--- a/source/Program/desktop_drop.c
+++ b/source/Program/desktop_drop.c
@@ -388,7 +388,7 @@ BOOL desktop_drop_on_object(BackdropInfo *info, DOpusAppMessage **msg, BackdropO
 				}
 
 				// Restore CD
-				CurrentDir(old);
+				UnLock(CurrentDir(old));
 			}
 		}
 

--- a/source/Program/event_loop.c
+++ b/source/Program/event_loop.c
@@ -690,7 +690,7 @@ void event_loop()
 				if (int_msg->Class == IDCMP_MENUVERIFY)
 				{
 					// See if want to swallow it
-					backdrop_test_rmb(GUI->backdrop, int_msg, &msg_copy, TRUE);
+					backdrop_test_rmb(GUI->backdrop, int_msg, &msg_copy, BTRM_ICON);
 				}
 
 				// Reply to message if not refresh

--- a/source/Program/event_loop.c
+++ b/source/Program/event_loop.c
@@ -150,7 +150,6 @@ void event_loop()
 						// Free buffer
 						FreeVec(pathname);
 					}
-					break;
 				}
 
 				// Otherwise, re-open program

--- a/source/Program/filetypes_proc.c
+++ b/source/Program/filetypes_proc.c
@@ -119,7 +119,7 @@ void filetype_find_typelist(Lister *lister, short flags)
 				ok = 1;
 
 			// Need to get version?
-			else if (flags & SNIFFF_VERSION && !(entry->de_Flags & ENTF_VERSION))
+			else if (flags & SNIFFF_VERSION && entry->de_Node.dn_Type < 0 && !(entry->de_Flags & ENTF_VERSION))
 				ok = 1;
 
 			// Ok to do this one?

--- a/source/Program/function_filechange.c
+++ b/source/Program/function_filechange.c
@@ -104,7 +104,11 @@ static FileChange *alloc_filechange(void *memhandle, BOOL network)
 	FileChange *change;
 
 	if (!(change = AllocMemH(memhandle, sizeof(FileChange))) || !(change->fib = AllocDosObject(DOS_FIB, 0)))
+	{
+		if (change)
+			FreeMemH(change);
 		return NULL;
+	}
 
 	if (network)
 		change->network = AllocMemH(memhandle, sizeof(NetworkInfo));

--- a/source/Program/function_launch.c
+++ b/source/Program/function_launch.c
@@ -195,7 +195,11 @@ FunctionHandle *function_new_handle(struct MsgPort *port, BOOL small)
 	// Allocate handle
 	if (!(handle = AllocVec(sizeof(FunctionHandle), MEMF_CLEAR)) ||
 		!(handle->memory = NewMemHandle(2048, 1024, MEMF_CLEAR)))
+	{
+		if (handle)
+			FreeVec(handle);
 		return 0;
+	}
 
 	// Not small?
 	if (!small)
@@ -206,7 +210,19 @@ FunctionHandle *function_new_handle(struct MsgPort *port, BOOL small)
 			!(handle->filereq = AllocAslRequest(ASL_FileRequest, 0)) ||
 			!(handle->s_info = AllocDosObject(DOS_FIB, 0)) || !(handle->d_info = AllocDosObject(DOS_FIB, 0)) ||
 			!(handle->recurse_entry_data = AllocMemH(handle->memory, sizeof(FunctionEntry))))
+		{
+			if (handle->entry_memory)
+				FreeMemHandle(handle->entry_memory);
+			if (handle->filereq)
+				FreeAslRequest(handle->filereq);
+			if (handle->s_info)
+				FreeDosObject(DOS_FIB, handle->s_info);
+			if (handle->d_info)
+				FreeDosObject(DOS_FIB, handle->d_info);
+			FreeMemHandle(handle->memory);
+			FreeVec(handle);
 			return 0;
+		}
 	}
 
 	// Get current requester coordinates

--- a/source/Program/lister_title.c
+++ b/source/Program/lister_title.c
@@ -144,17 +144,50 @@ void lister_show_name(Lister *lister)
 
 			// Full?
 #ifndef USE_64BIT
-			if (buffer->buf_FreeDiskSpace < 10 || buffer->buf_TotalDiskSpace < 1000)
-				strcat(space_buf, "100");
+			{
+				unsigned long used_blocks, percent;
 
-			// Calculate percentage
-			else
+				// Calculate used blocks
+				used_blocks = buffer->buf_TotalDiskSpace - buffer->buf_FreeDiskSpace;
+
+				// Calculate percentage: (used_blocks * 100) / total_blocks
+				if (buffer->buf_TotalDiskSpace > 0)
+				{
+					percent = UMult32(used_blocks, 100) / buffer->buf_TotalDiskSpace;
+
+					// Cap at 100% (defensive against invalid values from emulators)
+					if (percent > 100)
+						percent = 100;
+
+					// Build percentage string
+					lsprintf(space_buf + strlen(space_buf),
+							 "%ld",
+							 percent);
+				}
+				else
+				{
+					strcpy(space_buf + strlen(space_buf), "100");
+				}
+			}
+#else
+			{
+				// USE_64BIT path - already correct, but add cap for safety
+				UQUAD percent;
+
+				if (buffer->buf_TotalDiskSpace64 > 0)
+				{
+					percent = ((buffer->buf_TotalDiskSpace64 - buffer->buf_FreeDiskSpace64) * 100) /
+							  buffer->buf_TotalDiskSpace64;
+					if (percent > 100)
+						percent = 100;
+					lsprintf(space_buf + strlen(space_buf), "%llu", percent);
+				}
+				else
+				{
+					strcpy(space_buf + strlen(space_buf), "100");
+				}
+			}
 #endif
-				DivideToString(space_buf + strlen(space_buf),
-							   (buffer->buf_TotalDiskSpace / 10) - (buffer->buf_FreeDiskSpace / 10),
-							   buffer->buf_TotalDiskSpace / 1000,
-							   0,
-							   (environment->env->settings.date_flags & DATE_1000SEP) ? GUI->decimal_sep : 0);
 
 			// Add percentage string
 			strcat(space_buf, "% ");

--- a/source/Program/main.c
+++ b/source/Program/main.c
@@ -560,7 +560,7 @@ void startup_init_gui()
 		GUI->date_length = 9;
 
 	// See if SysIHack is running
-	if (FindTask("« sysihack »"))
+	if (FindTask("ï¿½ sysihack ï¿½"))
 		GUI->flags |= GUIF_SYSIHACK;
 
 	// Allocate a string for spaces, and the global undo buffer
@@ -1228,6 +1228,7 @@ void startup_init_filetypes()
 }
 
 // Initialise file notifications
+// See documents/dopus5/ModuleDiscovery.md for a detailed explanation of the module discovery process.
 void startup_init_notification()
 {
 	// Start notification of filetype directory

--- a/source/Program/main.c
+++ b/source/Program/main.c
@@ -560,7 +560,7 @@ void startup_init_gui()
 		GUI->date_length = 9;
 
 	// See if SysIHack is running
-	if (FindTask("ï¿½ sysihack ï¿½"))
+	if (FindTask("« sysihack »"))
 		GUI->flags |= GUIF_SYSIHACK;
 
 	// Allocate a string for spaces, and the global undo buffer

--- a/source/Program/rexx_handler.c
+++ b/source/Program/rexx_handler.c
@@ -136,6 +136,9 @@ short STDARGS rexx_handler_msg_args(char *handler, DirBuffer *buffer, short flag
 		// Get result
 		res = msg->rm_Result1;
 
+		// Clear message
+		ClearRexxMsg(msg, count);
+
 		// Free message
 		DeleteRexxMsg(msg);
 	}

--- a/source/Program/rexx_handler.c
+++ b/source/Program/rexx_handler.c
@@ -140,6 +140,9 @@ short STDARGS rexx_handler_msg_args(char *handler, DirBuffer *buffer, short flag
 		DeleteRexxMsg(msg);
 	}
 
+	// Free the reply port
+	DeleteMsgPort(reply_port);
+
 	// Free despatch
 	FreeVec(desp);
 	return res;

--- a/source/makefile
+++ b/source/makefile
@@ -67,7 +67,7 @@ $(NAME) : all
 endif
 ###########################################################
 # Sets archive type & version.
-REVISION := 92
+REVISION := 93
 ifeq ($(debug), no)
 TYPE :=
 VERSION := _$(REVISION)_


### PR DESCRIPTION
I did some cleanup, added some internal documentation and fixed the build for newer GCC 6.5b versions.
I also confirmed it builds with the NDK3.2 as well as the NDK3.9.

The CI is updated also according to the current latest versions, and I switched the Docker image to use one that includes the NDK3.2 (since that is still being actively developed).

Fixes #9 